### PR TITLE
tests: Fix segfault in skip list test

### DIFF
--- a/test/tests/test_parallel_skip_list.h
+++ b/test/tests/test_parallel_skip_list.h
@@ -25,8 +25,7 @@ class ParallelSkipListTest : public ::testing::Test {
     Element::Initialize();
     parlay::random r;
 
-    auto elements_seq = parlay::sequence<Element>::uninitialized(kNumElements);
-
+    elements_seq = parlay::sequence<Element>::uninitialized(kNumElements);
     elements = elements_seq.data();
 
     // parlay::parallel_for(0, kNumElements, [&](int i) {
@@ -36,16 +35,14 @@ class ParallelSkipListTest : public ::testing::Test {
     for (int i = 0; i < kNumElements; i++) {
       auto rand = r.ith_rand(i);
       new (&elements[i]) Element(rand);
-      std::cout << "Element " << i << ": " << elements[i].GetHeight()
-                << std::endl;
     }
     PrimeSieve();
-    std::cout << "here" << std::endl;
   }
 
   ~ParallelSkipListTest() override { Element::Finish(); }
 
   // Class members declared here can be used by all tests
+  parlay::sequence<Element> elements_seq{};
   Element* elements;
   // const int kNumElements{1000};
 
@@ -116,7 +113,6 @@ TEST_F(ParallelSkipListTest, ReperesentativeTest2_JoiningAllElements) {
   // could be parallelized
   // Join all elements together
 
-  std::cout << "here 2" << std::endl;
   for (int i = 0; i < kNumElements - 1; i++) {
     Element::Join(&elements[i], &elements[i + 1]);
   }


### PR DESCRIPTION
Bug: In `ParallelSkipListTest`, we assign the member variable `elements` to be the data of a sequence `elements_seq`. But that sequence is local to the constructor and calls its destructor (or more specifically, the internal class `sequence_base::storage_impl` calls its destructor and mangles some stuff). Now member variable `elements` points to the data of a destructed sequence and bad stuff happens when the test tries to use it.

Fix: Make `elements_seq` a member variable so it doesn't get destructed right away