### PR TITLE
ETT: Remove unnecessary `len` arguments from interface

### DIFF
--- a/elektra.cpp
+++ b/elektra.cpp
@@ -55,7 +55,7 @@ int main() {
         ett_input.push_back(std::make_pair(u, v));
       }
     }
-    ett.BatchLink(ett_input, ett_input.size());
+    ett.BatchLink(ett_input);
     CheckAllPairsConnectivity(reference_solution, ett);
 
     std::cout << "Round " << i << ": " << ett_input.size()

--- a/elektra/batch_dynamic_connectivity/connectivity.h
+++ b/elektra/batch_dynamic_connectivity/connectivity.h
@@ -402,7 +402,7 @@ void BatchDynamicConnectivity::BatchAddEdges(
   // }
 
   // add tree edges
-  maxLevelEulerTree->BatchLink(treeEdges, treeEdges.size());
+  maxLevelEulerTree->BatchLink(treeEdges);
 
   // add to adjacancy list
   parlay::parallel_for(0, nonTreeEdges.size(), [&](int i) {
@@ -447,7 +447,7 @@ parlay::sequence<Vertex> BatchDynamicConnectivity::parallelLevelSearch(
     parlay::sequence<Vertex> &components,
     parlay::sequence<std::pair<int, int>> &promotedEdges, int level) {
   auto levelEulerTree = parallel_spanning_forests_[level];
-  levelEulerTree->BatchLink(promotedEdges, promotedEdges.size());
+  levelEulerTree->BatchLink(promotedEdges);
 
   auto ncomponents = parlay::map(components, [&](Vertex v) {
     return (Vertex)levelEulerTree->getRepresentative(v);
@@ -502,8 +502,7 @@ parlay::sequence<Vertex> BatchDynamicConnectivity::parallelLevelSearch(
       }
       R.push_back(componentSearch(level, v));
     }
-    parallel_spanning_forests_[level - 1]->BatchLink(edgesToDropLevel,
-                                                     edgesToDropLevel.size());
+    parallel_spanning_forests_[level - 1]->BatchLink(edgesToDropLevel);
 
     auto maxLevelEulerTree = parallel_spanning_forests_[max_level_];
     auto auxiliaryEdges = parlay::map(R, [&](UndirectedEdge e) {
@@ -530,7 +529,7 @@ parlay::sequence<Vertex> BatchDynamicConnectivity::parallelLevelSearch(
     //     notPromotedEdges.push_back(auxiliaryEdges[i]);
     // }
 
-    levelEulerTree->BatchLink(newPromotedEdges, newPromotedEdges.size());
+    levelEulerTree->BatchLink(newPromotedEdges);
 
     parlay::parallel_for(0, newPromotedEdges.size(), [&](size_t i) {
       UndirectedEdge e = {newPromotedEdges[i].first,
@@ -627,7 +626,7 @@ void BatchDynamicConnectivity::BatchDeleteEdges(
     parlay::sequence<std::pair<int, int>> toDeletePairSequence =
         edgeBatchToPairArray(toDelete);
 
-    levelEulerTree->BatchCut(toDeletePairSequence, toDelete.size());
+    levelEulerTree->BatchCut(toDeletePairSequence);
   }
 
   parlay::sequence<Vertex> lcomponents =

--- a/test/tests/test_parallel_euler_tour_tree.h
+++ b/test/tests/test_parallel_euler_tour_tree.h
@@ -63,13 +63,13 @@ TEST(ParallelEulerTourTreeTest, BigStarGraphs) {
   }
   links[n - 2] = make_pair(n / 2, n / 2 + 1);
 
-  ett.BatchLink(links, links.size());
+  ett.BatchLink(links);
   EXPECT_TRUE(ett.IsConnected(0, 1));
   EXPECT_TRUE(ett.IsConnected(0, n / 2));
   EXPECT_TRUE(ett.IsConnected(0, n - 1));
   EXPECT_TRUE(ett.IsConnected(n / 2, n / 2 + 1));
 
-  ett.BatchCut(cuts, cuts.size());
+  ett.BatchCut(cuts);
   EXPECT_FALSE(ett.IsConnected(0, 1));
   EXPECT_FALSE(ett.IsConnected(0, n / 2));
   EXPECT_FALSE(ett.IsConnected(0, n - 1));


### PR DESCRIPTION
There are several functions in `EulerTourTree` that take a `len` argument, but we don't need that argument since we can get the `len` from the `parlay::sequence` argument. The `len` argument is a holdover from old code that passed pointers-to-arrays rather than `paraly::sequence`s.