### PR TITLE
ETT: Add function to return tree edges of component (rather than vertices of component)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,11 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/elektra)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external/parlaylib/include/)
 include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest/googlemock/include)
+include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/external/googletest/googletest/include)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/googletest/googletest/)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/googletest/)
 
 find_package(Boost REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
@@ -84,7 +86,7 @@ target_link_libraries(elektra ${Boost_LIBRARIES})
 
 # Testing
 add_executable(elektra_test test/elektra_test.cpp)
-target_link_libraries(elektra_test gtest_main)
+target_link_libraries(elektra_test gmock_main gtest_main)
 include(GoogleTest)
 gtest_discover_tests(elektra_test)
 

--- a/elektra/batch_dynamic_connectivity/connectivity.h
+++ b/elektra/batch_dynamic_connectivity/connectivity.h
@@ -199,7 +199,7 @@ class BatchDynamicConnectivity {
 
   treeSet getSpanningTree(const parlay::sequence<UndirectedEdge> &se);
 
-  void BatchDynamicConnectivity::replacementSearch(
+  void replacementSearch(
       int level, parlay::sequence<int> components,
       parlay::sequence<pair<int, int>> &promotedEdges);
 

--- a/elektra/batch_dynamic_connectivity/graph.h
+++ b/elektra/batch_dynamic_connectivity/graph.h
@@ -18,6 +18,7 @@ struct UndirectedEdge {
    *  @param[in] v The other endpoint of the edge.
    */
   UndirectedEdge(Vertex u, Vertex v) : first(u), second(v){};
+  UndirectedEdge(std::pair<Vertex, Vertex> e) : first(e.first), second(e.second){};
   UndirectedEdge() = delete;
 
   /** One endpoint of the edge. */

--- a/test/tests/test_parallel_euler_tour_tree.h
+++ b/test/tests/test_parallel_euler_tour_tree.h
@@ -6,12 +6,17 @@
 #include <utility>
 
 #include "../../elektra/parallel_euler_tour_tree/euler_tour_tree.hpp"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace elektra::testing {
 namespace {
 
 namespace pett = parallel_euler_tour_tree;
+
+using ::testing::IsEmpty;
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
 
 TEST(ParallelEulerTourTreeTest, IsDisconnectedInitially) {
   const pett::EulerTourTree ett = pett::EulerTourTree{3};
@@ -75,6 +80,17 @@ TEST(ParallelEulerTourTreeTest, BigStarGraphs) {
   EXPECT_FALSE(ett.IsConnected(0, n / 2));
   EXPECT_FALSE(ett.IsConnected(0, n - 1));
   EXPECT_TRUE(ett.IsConnected(n / 2, n / 2 + 1));
+}
+
+TEST(ParallelEulerTourTreeTest, ComponentEdges) {
+  pett::EulerTourTree ett = pett::EulerTourTree{6};
+  ett.Link(0, 2);
+  ett.Link(1, 2);
+  ett.Link(3, 5);
+
+  EXPECT_THAT(ett.ComponentEdges(0), UnorderedElementsAre(Pair(0, 2), Pair(1, 2)));
+  EXPECT_THAT(ett.ComponentEdges(3), UnorderedElementsAre(Pair(3, 5)));
+  EXPECT_THAT(ett.ComponentEdges(4), IsEmpty());
 }
 
 }  // namespace


### PR DESCRIPTION
As requested by Sualeh, this PR replaces `EulerTourTree::ConnectedComponent()` (returns vertices of connected component) with `EulerTourTree::ComponentEdges()` (returns tree edges of connected component).