### PR TITLE
ETT: Make GetRepresentative return a vertex

### DIFF
--- a/elektra/batch_dynamic_connectivity/dynamic_connectivity.h
+++ b/elektra/batch_dynamic_connectivity/dynamic_connectivity.h
@@ -58,8 +58,8 @@ void BatchDynamicConnectivity::BatchAddEdges(
   sequence<UndirectedEdge> auxiliaryEdges =
       parlay::map(se, [&](UndirectedEdge e) {
         return UndirectedEdge(
-            (V)maxLevelEulerTree->getRepresentative(e.first),
-            (V)maxLevelEulerTree->getRepresentative(e.second));
+            (V)maxLevelEulerTree->GetRepresentative(e.first),
+            (V)maxLevelEulerTree->GetRepresentative(e.second));
       });
   auto tree = getSpanningTree(auxiliaryEdges);
 
@@ -130,8 +130,8 @@ UndirectedEdge BatchDynamicConnectivity::componentSearch(int level, V v) {
       }
       seen_vertices.insert(u);
       for (auto w : non_tree_adjacency_lists_[level][u]) {
-        if (levelEulerTree->getRepresentative(u) !=
-            levelEulerTree->getRepresentative(v)) {
+        if (levelEulerTree->GetRepresentative(u) !=
+            levelEulerTree->GetRepresentative(v)) {
           return UndirectedEdge(u, w);
         }
       }
@@ -205,8 +205,8 @@ void BatchDynamicConnectivity::replacementSearch(
             auto u = e.first;
             auto v = e.second;
 
-            auto u_rep = ett->getRepresentative(u);
-            auto v_rep = ett->getRepresentative(v);
+            auto u_rep = ett->GetRepresentative(u);
+            auto v_rep = ett->GetRepresentative(v);
 
             auto u_parent = UF.find_set(u_rep);
             auto v_parent = UF.find_set(v_rep);
@@ -309,11 +309,11 @@ void BatchDynamicConnectivity::BatchDeleteEdges(
 
     sequence<int> lcomponents =
         parlay::map(edgesToReplace, [&](UndirectedEdge e) {
-          return levelEulerTree->getRepresentative(e.first);
+          return levelEulerTree->GetRepresentative(e.first);
         });
     sequence<int> rcomponents =
         parlay::map(edgesToReplace, [&](UndirectedEdge e) {
-          return levelEulerTree->getRepresentative(e.second);
+          return levelEulerTree->GetRepresentative(e.second);
         });
     lcomponents.append(rcomponents);
 
@@ -344,7 +344,7 @@ void BatchDynamicConnectivity::BatchDeleteEdges(
 //   levelEulerTree->BatchLink(promotedEdges);
 
 //   auto ncomponents = parlay::map(
-//       components, [&](V v) { return (V)levelEulerTree->getRepresentative(v);
+//       components, [&](V v) { return (V)levelEulerTree->GetRepresentative(v);
 //       });
 //   components = ncomponents;
 //   // components = removeDuplicates(components);
@@ -395,8 +395,8 @@ void BatchDynamicConnectivity::BatchDeleteEdges(
 
 //     auto maxLevelEulerTree = parallel_spanning_forests_[max_level_];
 //     auto auxiliaryEdges = parlay::map(R, [&](UndirectedEdge e) {
-//       return UndirectedEdge(maxLevelEulerTree->getRepresentative(e.first),
-//                             maxLevelEulerTree->getRepresentative(e.second));
+//       return UndirectedEdge(maxLevelEulerTree->GetRepresentative(e.first),
+//                             maxLevelEulerTree->GetRepresentative(e.second));
 //     });
 //     auto promIndices = getSpanningTree(auxiliaryEdges);
 
@@ -430,7 +430,7 @@ void BatchDynamicConnectivity::BatchDeleteEdges(
 //     });
 
 //     auto ccu = parlay::map(components_to_consider, [&](V v) {
-//       return (V)levelEulerTree->getRepresentative(v);
+//       return (V)levelEulerTree->GetRepresentative(v);
 //     });
 
 //     // components_to_consider = removeDuplicates(ccu);

--- a/test/tests/test_parallel_euler_tour_tree.h
+++ b/test/tests/test_parallel_euler_tour_tree.h
@@ -93,5 +93,29 @@ TEST(ParallelEulerTourTreeTest, ComponentEdges) {
   EXPECT_THAT(ett.ComponentEdges(4), IsEmpty());
 }
 
+TEST(ParallelEulerTourTreeTest, GetRepresentative) {
+  const int n = 8;
+  pett::EulerTourTree ett = pett::EulerTourTree{n};
+
+  ett.Link(0, 1);
+  ett.Link(0, 2);
+  ett.Link(1, 3);
+  ett.Link(1, 4);
+  ett.Link(6, 7);
+
+  std::vector<int> reps(n);
+  for (int i = 0; i < n; i++) {
+    reps[i] = ett.GetRepresentative(i);
+  }
+  EXPECT_EQ(reps[0], reps[1]);
+  EXPECT_EQ(reps[0], reps[2]);
+  EXPECT_EQ(reps[0], reps[3]);
+  EXPECT_EQ(reps[0], reps[4]);
+  EXPECT_NE(reps[0], reps[5]);
+  EXPECT_NE(reps[0], reps[6]);
+  EXPECT_NE(reps[5], reps[6]);
+  EXPECT_EQ(reps[6], reps[7]);
+}
+
 }  // namespace
 }  // namespace elektra::testing


### PR DESCRIPTION
Make `ETT.GetRepresentative()` return a vertex ID rather than an arbitrary skip list element. It may be a bit slower to retrieve the vertex ID, but a vertex ID is easier to use (e.g., easy to place in a hash table, e.g., if we link two components with representative vertices a and b, the linked components will have representative vertex a or b).