### PR TITLE
euler_tour_tree: Add function to estimate memory usage

### DIFF
--- a/elektra/concurrentMap.h
+++ b/elektra/concurrentMap.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <parlay/parallel.h>
+#include <parlay/primitives.h>
+#include <parlay/sequence.h>
+#include <parlay/slice.h>
 #include <parlay/utilities.h>
 
 #include <tuple>
@@ -169,6 +172,14 @@ class concurrentHT {
       }
       h = incrementIndex(h);
     }
+  }
+
+  // Return non-empty entries in the map.
+  parlay::sequence<KV> entries() const {
+    return parlay::filter(parlay::slice(table, table + capacity), [&](const KV& kv) {
+      const K& k = std::get<0>(kv);
+      return k != empty_key && k != tombstone;
+    });
   }
 };
 


### PR DESCRIPTION
Add function `EulerTourTree::MemorySize()` that estimates the amount of memory used by the EulerTourTree, including `sizeof(EulerTourTree)` and all the other classes is allocates.

## Testing

Allocated an EulerTourTree of size 10^5 + inserted some elements, printed out the `MemorySize()`, and looked at the peak memory usage of the program `/usr/bin/time -l`, then repeated that with size 10^7, and checked that the change in `MemorySize()` is close to the change in the peak memory usage between the two runs