### PR TITLE
ETT: Add HdtEulerTourTree with support for multiple subtree queries

### DIFF
--- a/elektra/concurrentMap.h
+++ b/elektra/concurrentMap.h
@@ -45,14 +45,8 @@ struct maybe {
 
 #if defined(LONG)
 typedef long intT;
-typedef unsigned long uintT;
-#define INT_T_MAX LONG_MAX
-#define UINT_T_MAX ULONG_MAX
 #else
 typedef int intT;
-typedef unsigned int uintT;
-#define INT_T_MAX INT_MAX
-#define UINT_T_MAX UINT_MAX
 #endif
 
 namespace concurrent_map {

--- a/elektra/parallel_euler_tour_tree/edge_map.h
+++ b/elektra/parallel_euler_tour_tree/edge_map.h
@@ -12,25 +12,21 @@ namespace parallel_euler_tour_tree {
 
 namespace _internal {
 
-// The element allocator is used to allocate and deallocate elements.
-// It is used to allocate the elements in the skip list.
-// This is borrowed from parlay's type allocator.
-using ElementAllocator = parlay::type_allocator<Element>;
-
 // Used in Euler tour tree for mapping directed edges (pairs of ints) to the
 // sequence element in the Euler tour representing the edge.
 //
 // Only one of (u, v) and (v, u) should be added to the map; we can find the
-// other edge using the `twin_` pointer in `Element`.
+// other edge using the `twin_` pointer in `Elem`.
+template <typename Elem>
 class EdgeMap {
  public:
   EdgeMap() = delete;
   explicit EdgeMap(int num_vertices);
   ~EdgeMap();
 
-  bool Insert(int u, int v, Element* edge);
+  bool Insert(int u, int v, Elem* edge);
   bool Delete(int u, int v);
-  Element* Find(int u, int v);
+  Elem* Find(int u, int v);
 
   int IsEmpty() const;
 
@@ -40,25 +36,31 @@ class EdgeMap {
 
   // Returns an estimate of the amount of memory in bytes this element occupies
   // beyond what's captured by sizeof(EdgeMap). This includes the amount of
-  // memory occupied by the `Element`s allocated and inserted as values into the
+  // memory occupied by the `Elem`s allocated and inserted as values into the
   // map.
   size_t AllocatedMemorySize() const;
 
  private:
-  concurrent_map::concurrentHT<std::pair<int, int>, Element*, HashIntPairStruct>
+  using ElementAllocator = parlay::type_allocator<Elem>;
+
+  concurrent_map::concurrentHT<std::pair<int, int>, Elem*, HashIntPairStruct>
       map_;
 };
 
-EdgeMap::EdgeMap(int num_vertices)
+template <typename Elem>
+EdgeMap<Elem>::EdgeMap(int num_vertices)
     : map_{nullptr, static_cast<size_t>(num_vertices - 1),
            std::make_pair(-1, -1), std::make_pair(-2, -2)} {}
 
-EdgeMap::~EdgeMap() { map_.del(); }
+template <typename Elem>
+EdgeMap<Elem>::~EdgeMap() { map_.del(); }
 
 // Check whether the hash table is empty.
-int EdgeMap::IsEmpty() const { return map_.n_elms == 0; }
+template <typename Elem>
+int EdgeMap<Elem>::IsEmpty() const { return map_.n_elms == 0; }
 
-bool EdgeMap::Insert(int u, int v, Element* edge) {
+template <typename Elem>
+bool EdgeMap<Elem>::Insert(int u, int v, Elem* edge) {
   if (u > v) {
     std::swap(u, v);
     edge = edge->twin_;
@@ -66,16 +68,18 @@ bool EdgeMap::Insert(int u, int v, Element* edge) {
   return map_.insert(make_pair(u, v), edge);
 }
 
-bool EdgeMap::Delete(int u, int v) {
+template <typename Elem>
+bool EdgeMap<Elem>::Delete(int u, int v) {
   if (u > v) {
     std::swap(u, v);
   }
   return map_.deleteVal(make_pair(u, v));
 }
 
-Element* EdgeMap::Find(int u, int v) {
+template <typename Elem>
+Elem* EdgeMap<Elem>::Find(int u, int v) {
   if (u > v) {
-    Element* vu{*map_.find(make_pair(v, u))};
+    Elem* vu{*map_.find(make_pair(v, u))};
     return vu == nullptr ? nullptr : vu->twin_;
   } else {
     return *map_.find(make_pair(u, v));
@@ -83,26 +87,27 @@ Element* EdgeMap::Find(int u, int v) {
 }
 
 // Assumes that all elements were allocator using ElementAllocator.
-
-void EdgeMap::FreeElements() {
+template <typename Elem>
+void EdgeMap<Elem>::FreeElements() {
   parlay::parallel_for(0, map_.capacity, [&](size_t i) {
     auto kv{map_.table[i]};
     auto key{get<0>(kv)};
     if (key != map_.empty_key && key != map_.tombstone) {
-      Element* element{get<1>(kv)};
-      element->twin_->~Element();
+      Elem* element{get<1>(kv)};
+      element->twin_->~Elem();
       ElementAllocator::free(element->twin_);
-      element->~Element();
+      element->~Elem();
       ElementAllocator::free(element);
     }
   });
 }
 
-size_t EdgeMap::AllocatedMemorySize() const {
+template <typename Elem>
+size_t EdgeMap<Elem>::AllocatedMemorySize() const {
   return sizeof(map_.table[0]) * map_.capacity +
     parlay::reduce(
-      parlay::map(map_.entries(), [&](std::tuple<std::pair<int, int>, Element*> kv) {
-        const Element* elem{std::get<1>(kv)};
+      parlay::map(map_.entries(), [&](std::tuple<std::pair<int, int>, Elem*> kv) {
+        const Elem* elem{std::get<1>(kv)};
         // Count both elem and elem->twin_ since only one appears in map_.
         return 2 * sizeof(*elem) + elem->AllocatedMemorySize() + elem->twin_->AllocatedMemorySize();
       })

--- a/elektra/parallel_euler_tour_tree/element.h
+++ b/elektra/parallel_euler_tour_tree/element.h
@@ -69,6 +69,7 @@ class Element : public ElementBase<Element, parlay::addm<int>> {
   size_t GetComponentSize() const;
 
  private:
+  // make parallel_skip_list::ElementBase a friend
   friend Base::Base::Base;
 
   // Gets edges held in descendants of this element and writes them into

--- a/elektra/parallel_euler_tour_tree/euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/euler_tour_tree.h
@@ -79,7 +79,7 @@ class EulerTourTreeBase {
   using ElementAllocator = parlay::type_allocator<Elem>;
   int num_vertices_;
   parlay::sequence<Elem> vertices_;
-  _internal::EdgeMap edges_;
+  _internal::EdgeMap<Elem> edges_;
   parlay::random randomness_;
 
   // This version of `Link` can be used if `Elem`s representing edges should be

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -71,7 +71,7 @@ class HdtElement : public ElementBase<HdtElement, _internal::HdtAugmentation> {
   // In the list that contains this element, returns all level-i tree edges
   // and mark them as no longer being level-i tree edges (because they're going
   // to be pushed down to the next level).
-  parlay::sequence<std::pair<int, int>> ClearLevelIEdges();
+  parlay::sequence<std::pair<int, int>> GetAndClearLevelIEdges();
 
   // For each HdtElement elements[i] (which should represent a vertex), updates
   // its count of "number of level-i non-tree edges incident to this element" to
@@ -108,7 +108,7 @@ size_t HdtElement::GetComponentSize() const {
   return num_vertices;
 }
 
-// Helper function for ClearLevelIEdges. Gets edges held in descendants of
+// Helper function for GetAndClearLevelIEdges. Gets edges held in descendants of
 // this element and writes them into the sequence starting at the offset.
 void HdtElement::GetLevelIEdgesBelow(parlay::sequence<HdtElement*>* s, int level, uint32_t offset) const {
   if (level == 0) {
@@ -147,7 +147,7 @@ void HdtElement::GetLevelIEdgesBelow(parlay::sequence<HdtElement*>* s, int level
   }
 }
 
-parlay::sequence<std::pair<int, int>> HdtElement::ClearLevelIEdges() {
+parlay::sequence<std::pair<int, int>> HdtElement::GetAndClearLevelIEdges() {
   HdtElement* const top_element{FindRepresentative()};
   const int level{top_element->height_ - 1};
 

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -297,7 +297,7 @@ void NontreeEdgeFinder::ForEachIncidentVertexImpl(
         search_offset = 0;
       }
       element = element->neighbors_[level].next;
-    } while ((element->height_ < level + 1 || is_top_level) && num_desired_edges > 0 && element == top_element_);
+    } while ((element->height_ < level + 1 || is_top_level) && num_desired_edges > 0 && element != top_element_);
     return;
   }
 
@@ -310,7 +310,7 @@ void NontreeEdgeFinder::ForEachIncidentVertexImpl(
   const auto loop_condition{[&](const LoopState& state) {
     return (state.element->height_ < level + 1 || is_top_level) &&
       num_desired_edges > 0 &&
-      element == top_element_;
+      element != top_element_;
   }};
   const auto loop_action{[&](const LoopState& state) {
     const uint64_t num_edges{std::get<2>(state.element->values_[level])};

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -132,10 +132,10 @@ HdtElement::HdtElement(size_t random_int, std::pair<int, int>&& id, bool is_leve
 
 size_t HdtElement::GetComponentSize() const {
   HdtElement* const top_element{FindRepresentative()};
-  const int level = top_element->height_ - 1;
+  const int level{top_element->height_ - 1};
 
   size_t num_vertices{0};
-  HdtElement* curr = top_element;
+  HdtElement* curr{top_element};
   do {
     num_vertices += std::get<0>(curr->values_[level]);
     curr = curr->neighbors_[level].next;
@@ -157,7 +157,7 @@ void HdtElement::GetLevelIEdgesBelowLoop(
     int offset,
     const HdtElement* curr,
     bool is_loop_start) {
-  if (is_loop_start || curr->height_ < level + 1) {
+  if (is_loop_start || curr->height_ <= level + 1) {
     parlay::par_do(
       [&]() { curr->GetLevelIEdgesBelow(s, level, offset); },
       [&]() {
@@ -204,7 +204,7 @@ void HdtElement::GetLevelIEdgesLoop(
     int offset,
     bool is_loop_start) {
   if (is_loop_start || curr != start_element) {
-    const int level = curr->height_ - 1;
+    const int level{curr->height_ - 1};
     parlay::par_do(
       [&]() { curr->GetLevelIEdgesBelow(s, level, offset); },
       [&]() {
@@ -221,7 +221,7 @@ void HdtElement::GetLevelIEdgesLoop(
 
 parlay::sequence<std::pair<int, int>> HdtElement::ClearLevelIEdges() {
   HdtElement* const top_element{FindRepresentative()};
-  const int level = top_element->height_ - 1;
+  const int level{top_element->height_ - 1};
 
   size_t num_edges{0};
   {

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -60,10 +60,12 @@ class HdtElement : public ElementBase<HdtElement, _internal::HdtAugmentation> {
   // whatever ETT this skip list lives in.
   explicit HdtElement(size_t random_int, std::pair<int, int>&& id, bool is_level_i_edge);
 
-  // Get the number of vertices in the sequence that contains this element.
+  // Get the number of vertices in the list that contains this element.
   size_t GetComponentSize() const;
 
-  // TODO(tomtseng) comment
+  // Creates a NontreeEdgeFinder based on the list that contains this element.
+  // The NontreeEdgeFinder can be used to find level-i non-tree edges incident
+  // to vertices in this list.
   NontreeEdgeFinder CreateNontreeEdgeFinder() const;
 
   // In the list that contains this element, return all level-i tree edges
@@ -84,50 +86,62 @@ class HdtElement : public ElementBase<HdtElement, _internal::HdtAugmentation> {
   friend Base::Base::Base;  // make parallel_skip_list::ElementBase a friend
   friend NontreeEdgeFinder;
 
-  // Helper function for ClearLevelIEdges. Gets edges held in descendants of
-  // this element at writes them into the sequence starting at the offset.
   void GetLevelIEdgesBelow(parlay::sequence<HdtElement*>* s, int level, uint32_t offset) const;
 };
 
-// TODO(tomtseng): comment and use this
+// A NontreeEdgeFinder allows the user to find level-i non-tree edges incident
+// to a particular list.
 //
-// no longer valid if u join/link//update the underlying component
-//
-// impl note: we just design this this way so we don't fetch the top_element
-// repeatedly lol
+// A NontreeEdgeFinder is no longer valid if the underlying list experiences a
+// join, a split, or an UpdateNontreeEdgeCounts().
 class NontreeEdgeFinder {
  public:
-  // TODO(tomtseng): comment
-  //
-  //  f should take a vertex_id, start_index, end_index, and should be able to
-  //  run in parallel
-  //
-  //  should return how many edges remaining
-  //
-  // In the skip list that contains this element, return a list of vertices adjacent
-  // to `num_edges` level-i non-tree edges.
+  // The returns the number of level-i non-tree edges incident to the connected
+  // component.
+  uint64_t NumEdges() const;
+
+  // This function finds elements in the list that have incident level-i
+  // non-tree edges and applies `f` to the elements. The edges found are the
+  // first `num_edges` edges after skipping the first `search_offset` edges.
   //
   // Params:
-  // - num_edges: Specifies how many level-i non-tree edges to search for
+  // - f: A parallel function to apply to elements that have incident edges. The
+  //   interface of f should be `void f(uint32_t vertex_id, uint32_t begin,
+  //   uint32_t end)` where the arguments signify that f should operate upon the
+  //   `begin`-th (inclusive) to `end`-th (exclusive) level-i non-tree edges for
+  //   vertex `vertex_id`.
+  // - num_edges: Specifies how many level-i non-tree edges to search for.
   // - search_offset: Specifies prefix of non-tree edges to skip in the search.
-  //     For instance, suppose you've already found 50 edges using
-  //     FindNontreeIncidentVertices(50, 0). Then you can find the next 100
-  //     edges using FindNontreeIncidentVertices(100, 50).
-  //
+  //   For instance, suppose you've already found 50 edges using
+  //   FindNontreeIncidentVertices(f, 50, 0). Then you can find the next 20 edges
+  //   using FindNontreeIncidentVertices(f, 20, 50).
   template <typename Func>
   void ForEachIncidentVertex(Func f, uint64_t num_desired_edges, uint64_t search_offset) const;
-
-  // TODO(tomtseng): comment
-  uint64_t NumEdges() const;
 
  private:
   friend HdtElement;
 
   NontreeEdgeFinder(const HdtElement* top_element);
 
+  template <typename F>
+  void ForEachIncidentVertexImpl(
+      F f,
+      uint64_t num_desired_edges,
+      uint64_t search_offset,
+      int level,
+      const HdtElement* element) const;
+
+  // A fixed representative element of the list.
   const HdtElement* top_element_;
-  // TODO(tomtseng): populate and comment
+  // The number of level-i non-tree edges incident to this component.
   uint64_t num_incident_edges_{0};
+  // The max level in the list.
+  const int top_level_;
+
+  // Implementation notes:
+  // - We implement this as separate class from HdtElement just to avoid recalculating
+  //   top_element_ every time we call ForEachIncidentVertex. This optimization is
+  //   probably completely insignificant.
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -156,6 +170,8 @@ NontreeEdgeFinder HdtElement::CreateNontreeEdgeFinder() const {
   return NontreeEdgeFinder{FindRepresentative()};
 }
 
+// Helper function for ClearLevelIEdges. Gets edges held in descendants of
+// this element and writes them into the sequence starting at the offset.
 void HdtElement::GetLevelIEdgesBelow(parlay::sequence<HdtElement*>* s, int level, uint32_t offset) const {
   if (level == 0) {
     if (std::get<1>(values_[0])) {
@@ -238,7 +254,7 @@ void HdtElement::UpdateNontreeEdgeCounts(
 }
 
 NontreeEdgeFinder::NontreeEdgeFinder(const HdtElement* top_element)
-  : top_element_{top_element} {
+  : top_element_{top_element}, top_level_{top_element->height_ - 1} {
   const HdtElement* curr{top_element};
   const int level{top_element_->height_ - 1};
   do {
@@ -251,24 +267,79 @@ uint64_t NontreeEdgeFinder::NumEdges() const {
   return num_incident_edges_;
 }
 
+// Helper function for ForEachIncidentVertex. Searches descendants of this
+// element for the first `num_desired_edges` level-i non-tree edges after
+// skipping the first `search_offset` edges. If searching at the top level,
+// perform this descendant-search on all elements at the top level, not just
+// `element`.
+template <typename F>
+void NontreeEdgeFinder::ForEachIncidentVertexImpl(
+    F f,
+    uint64_t num_desired_edges,
+    uint64_t search_offset,
+    int level,
+    const HdtElement* element) const {
+  const bool is_top_level{level == top_level_};
+  if (level <= 6) {
+    // run sequentially if we're near the bottom of the list and not doing as
+    // much work per thread
+    do {
+      const uint64_t num_edges{std::get<2>(element->values_[level])};
+      if (search_offset >= num_edges) {
+        search_offset -= num_edges;
+      } else {
+        if (level == 0) {
+          f(element->id_.first, search_offset, std::min<uint64_t>(search_offset + num_desired_edges, num_edges));
+        } else {
+          ForEachIncidentVertexImpl(f, num_desired_edges, search_offset, level - 1, element);
+        }
+        num_desired_edges -= num_edges - search_offset;
+        search_offset = 0;
+      }
+      element = element->neighbors_[level].next;
+    } while ((element->height_ < level + 1 || is_top_level) && num_desired_edges > 0 && element == top_element_);
+    return;
+  }
+
+  // run in parallel
+  struct LoopState {
+    const HdtElement* element;
+    uint64_t num_desired_edges;
+    uint64_t search_offset;
+  } loop_state = { element, num_desired_edges, search_offset };
+  const auto loop_condition{[&](const LoopState& state) {
+    return (state.element->height_ < level + 1 || is_top_level) &&
+      num_desired_edges > 0 &&
+      element == top_element_;
+  }};
+  const auto loop_action{[&](const LoopState& state) {
+    const uint64_t num_edges{std::get<2>(state.element->values_[level])};
+    if (state.search_offset >= num_edges) {
+      return;
+    }
+    ForEachIncidentVertexImpl(f, state.num_desired_edges, state.search_offset, level - 1, state.element);
+  }};
+  const auto loop_update{[&](LoopState state) -> LoopState {
+    uint64_t num_edges{std::get<2>(state.element->values_[level])};
+    if (state.search_offset >= num_edges) {
+      state.search_offset -= num_edges;
+    } else {
+      state.num_desired_edges -= num_edges - state.search_offset;
+      state.search_offset = 0;
+    }
+    state.element = state.element->neighbors_[level].next;
+    return state;
+  }};
+  constexpr bool is_do_while{true};
+  elektra::ParallelWhile(loop_condition, loop_action, loop_update, std::move(loop_state), is_do_while);
+}
+
 template <typename F>
 void NontreeEdgeFinder::ForEachIncidentVertex(
     F f,
     uint64_t num_desired_edges,
     uint64_t search_offset) const {
-  num_desired_edges = std::min<uint64_t>(num_incident_edges_ - search_offset, num_desired_edges);
-
-  const HdtElement* curr{top_element_};
-  const int level{top_element_->height_ - 1};
-  // TODO(tomtseng) parallelize
-  do {
-    const uint64_t num_edges_of_curr{std::get<2>(curr->values_[level])};
-    if (search_offset >= num_edges_of_curr) {
-      search_offset -= num_edges_of_curr;
-    } else {
-      // TODO(tomtseng) impl
-    }
-  } while (curr != top_element_);
+  ForEachIncidentVertexImpl(f, num_desired_edges, search_offset, top_level_, top_element_);
 }
 
 }  // namespace parallel_euler_tour_tree

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -1,0 +1,254 @@
+#pragma once
+
+#include <parlay/delayed_sequence.h>
+#include <parlay/primitives.h>
+#include <parlay/sequence.h>
+
+#include "element.h"
+
+namespace parallel_euler_tour_tree {
+
+namespace _internal {
+
+struct HdtAugmentation {
+  // 0. Augment each vertex element to get "number of vertices in this list".
+  // 1. Augment each edge element to get "number of level-i edges in this list".
+  // 2. Augment each vertex element to get "number of level-i non-tree edges
+  //    incident to vertices in this list".
+  using T = std::tuple<uint32_t, uint32_t, uint64_t>;
+  static T f(const T& a, const T& b) {
+    return {
+      std::get<0>(a) + std::get<0>(b),
+      std::get<1>(a) + std::get<1>(b),
+      std::get<2>(a) + std::get<2>(b),
+    };
+  }
+};
+
+template <typename Tuple, int Index>
+struct IntTupleGetter {
+  using T = std::tuple_element_t<Index, Tuple>;
+  static inline T& Get(Tuple& elem) {
+    return std::get<Index>(elem);
+  }
+  static T f(T a, T b) {
+    return a + b;
+  }
+};
+
+// Structs for use in `HdtElement::BatchUpdate()` that apply `HdtAugmentation`
+// at a single index of the tuple `HdtAugmentation::T`.
+using IsLevelIEdgeGetter = IntTupleGetter<HdtAugmentation::T, 1>;
+using NontreeEdgeCountGetter = IntTupleGetter<HdtAugmentation::T, 2>;
+
+}  // namespace _internal
+
+// Skip list element augmented to be useful for HDT-like dynamic connectivity
+// algorithm. (HDT = Holm + De Lichtenberg + Thorup, referring to authors of a
+// dynamic connectivity algorithm.)
+//
+// Most of the functions in this class assume that the list is circular.
+class HdtElement : public ElementBase<HdtElement, _internal::HdtAugmentation> {
+ public:
+  using Base = ElementBase<HdtElement, _internal::HdtAugmentation>;
+
+  // `is_level_i_edge` refers to whether this element represents a level-i tree
+  // edge, where "level-i" refers to be the level (in the HDT algorithm) of
+  // whatever ETT this skip list lives in.
+  explicit HdtElement(size_t random_int, std::pair<int, int>&& id, bool is_level_i_edge);
+
+  // Get the number of vertices in the sequence that contains this element.
+  size_t GetComponentSize() const;
+
+  // In the skip list that contains this element, return a list of vertices adjacent
+  // to `num_edges` level-i non-tree edges.
+  //
+  // Params:
+  // - num_edges: Specifies how many level-i non-tree edges to search for
+  // - search_offset: Specifies prefix of non-tree edges to skip in the search.
+  //     For instance, suppose you've already found 50 edges using
+  //     FindNonTreeIncidentVertices(50, 0). Then you can find the next 100
+  //     edges using FindNonTreeIncidentVertices(100, 50).
+  //
+  // Returns:
+  // - A list L of vertices
+  // - A initial offset s for L[0]
+  // - An ending offset t for L[-1]
+  // Taking the level-i non-tree edges of L[0] starting at index s, of L[1]
+  // through L[-2], and of L[-1] up to index t (exclusive) will either give
+  // num_edges edges or give all the remaining edges excluding those skipped by
+  // search_offset.
+  // If L is empty then there were no edges found.
+  std::tuple<parlay::sequence<int>, int, int> FindNonTreeIncidentVertices(
+      size_t num_edges,
+      size_t search_offset) const;
+
+  // In the list that contains this element, return all level-i tree edges
+  // and mark them as no longer being level-i tree edges (because they're going
+  // to be pushed down to the next level).
+  parlay::sequence<std::pair<int, int>> ClearLevelIEdges();
+
+  // Updates the counts of "number of level-i non-tree edges incident to this
+  // vertex" for each element (which should represent a vertex) in `elements`.
+  //
+  // `IntSeq` should behave like `parlay::sequence<int>`.
+  template <typename IntSeq>
+  static void UpdateNontreeEdgeCounts(
+      const parlay::sequence<HdtElement*>& elements,
+      IntSeq&& new_values);
+
+ private:
+  // make parallel_skip_list::ElementBase a friend
+  friend Base::Base::Base;
+
+  // Helper function for ClearLevelIEdges that populates `s` with elements
+  // representing level-i tree edges.
+  static void GetLevelIEdgesLoop(
+      parlay::sequence<HdtElement*>* s,
+      const HdtElement* start_element,
+      const HdtElement* curr,
+      int offset = 0,
+      bool is_loop_start = true);
+  // Helper function for ClearLevelIEdges. Gets edges held in descendants of
+  // this element at writes them into the sequence starting at the offset.
+  void GetLevelIEdgesBelow(parlay::sequence<HdtElement*>* s, int level, int offset) const;
+  // Helper function for GetEdgesBelow.
+  static void GetLevelIEdgesBelowLoop(
+      parlay::sequence<HdtElement*>* s,
+      int level,
+      int offset,
+      const HdtElement* curr,
+      bool is_loop_start = true);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+//                           Implementation below.                           //
+///////////////////////////////////////////////////////////////////////////////
+
+HdtElement::HdtElement(size_t random_int, std::pair<int, int>&& id, bool is_level_i_edge)
+  // Using std::move(id) and also accessing id's fields is sketchy but should
+  // be OK since std::move's immediate effect is really just a cast.
+  : Base{random_int, std::move(id), {id.first == id.second, id.first < id.second && is_level_i_edge, 0}} {}
+
+size_t HdtElement::GetComponentSize() const {
+  HdtElement* const top_element{FindRepresentative()};
+  const int level = top_element->height_ - 1;
+
+  size_t num_vertices{0};
+  HdtElement* curr = top_element;
+  do {
+    num_vertices += std::get<0>(curr->values_[level]);
+    curr = curr->neighbors_[level].next;
+  } while (curr != top_element);
+  return num_vertices;
+}
+
+std::tuple<parlay::sequence<int>, int, int> HdtElement::FindNonTreeIncidentVertices(
+    size_t num_edges,
+    size_t search_offset) const {
+  // TODO(tomtseng)
+  std::cerr << "TODO(tomtseng): unimplemented\n";
+  exit(-1);
+}
+
+void HdtElement::GetLevelIEdgesBelowLoop(
+    parlay::sequence<HdtElement*>* s,
+    int level,
+    int offset,
+    const HdtElement* curr,
+    bool is_loop_start) {
+  if (is_loop_start || curr->height_ < level + 1) {
+    parlay::par_do(
+      [&]() { curr->GetLevelIEdgesBelow(s, level, offset); },
+      [&]() {
+        GetLevelIEdgesBelowLoop(
+            s,
+            level,
+            offset + std::get<1>(curr->values_[level]),
+            curr->neighbors_[level].next,
+            false);
+      }
+    );
+  }
+}
+
+void HdtElement::GetLevelIEdgesBelow(parlay::sequence<HdtElement*>* s, int level, int offset) const {
+  if (level == 0) {
+    if (std::get<1>(values_[0])) {
+      (*s)[offset] = const_cast<HdtElement*>(this);
+    }
+    return;
+  }
+  if (std::get<1>(values_[level]) == 0) {
+    return;
+  }
+
+  const HdtElement* curr{this};
+  if (level <= 6) {
+    // run sequentially once we're near the bottom of the list and not doing as
+    // much work per thread
+    do {
+      curr->GetLevelIEdgesBelow(s, level - 1, offset);
+      offset += std::get<1>(curr->values_[level - 1]);
+      curr = curr->neighbors_[level - 1].next;
+    } while (curr->height_ < level + 1);
+  } else {  // run in parallel
+    GetLevelIEdgesBelowLoop(s, level - 1, offset, this);
+  }
+}
+
+void HdtElement::GetLevelIEdgesLoop(
+    parlay::sequence<HdtElement*>* s,
+    const HdtElement* start_element,
+    const HdtElement* curr,
+    int offset,
+    bool is_loop_start) {
+  if (is_loop_start || curr != start_element) {
+    const int level = curr->height_ - 1;
+    parlay::par_do(
+      [&]() { curr->GetLevelIEdgesBelow(s, level, offset); },
+      [&]() {
+        GetLevelIEdgesLoop(
+            s,
+            start_element,
+            curr->neighbors_[level].next,
+            offset + std::get<1>(curr->values_[level]),
+            false);
+      }
+    );
+  }
+}
+
+parlay::sequence<std::pair<int, int>> HdtElement::ClearLevelIEdges() {
+  HdtElement* const top_element{FindRepresentative()};
+  const int level = top_element->height_ - 1;
+
+  size_t num_edges{0};
+  {
+    HdtElement* curr = top_element;
+    do {
+      num_edges += std::get<1>(curr->values_[level]);
+      curr = curr->neighbors_[level].next;
+    } while (curr != top_element);
+  }
+
+  parlay::sequence<HdtElement*> edge_elements(num_edges);
+  GetLevelIEdgesLoop(&edge_elements, top_element, top_element);
+
+  BatchUpdate<_internal::IsLevelIEdgeGetter>(
+      edge_elements,
+      parlay::delayed_seq<int>(num_edges, [](size_t) { return 0; }));
+  parlay::sequence<std::pair<int, int>> edges{
+    parlay::map(edge_elements, [](const HdtElement* elem) { return elem->id_; })
+  };
+  return edges;
+}
+
+template <typename IntSeq>
+void HdtElement::UpdateNontreeEdgeCounts(
+    const parlay::sequence<HdtElement*>& elements,
+    IntSeq&& new_values) {
+  BatchUpdate<_internal::NontreeEdgeCountGetter>(elements, std::move(new_values));
+}
+
+}  // namespace parallel_euler_tour_tree

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -135,8 +135,6 @@ class NontreeEdgeFinder {
   const HdtElement* top_element_;
   // The number of level-i non-tree edges incident to this component.
   uint64_t num_incident_edges_{0};
-  // The max level in the list.
-  const int top_level_;
 
   // Implementation notes:
   // - We implement this as separate class from HdtElement just to avoid recalculating
@@ -254,7 +252,7 @@ void HdtElement::UpdateNontreeEdgeCounts(
 }
 
 NontreeEdgeFinder::NontreeEdgeFinder(const HdtElement* top_element)
-  : top_element_{top_element}, top_level_{top_element->height_ - 1} {
+  : top_element_{top_element} {
   const HdtElement* curr{top_element};
   const int level{top_element_->height_ - 1};
   do {
@@ -338,7 +336,8 @@ void NontreeEdgeFinder::ForEachIncidentVertex(
     F f,
     uint64_t num_desired_edges,
     uint64_t search_offset) const {
-  ForEachIncidentVertexImpl(f, num_desired_edges, search_offset, top_level_, top_element_);
+  const int level{top_element_->height_ - 1};
+  ForEachIncidentVertexImpl(f, num_desired_edges, search_offset, level, top_element_);
 }
 
 }  // namespace parallel_euler_tour_tree

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -77,7 +77,7 @@ class HdtElement : public ElementBase<HdtElement, _internal::HdtAugmentation> {
   // its count of "number of level-i non-tree edges incident to this element" to
   // be new_values[i].
   template <typename ElemSeq, typename IntSeq>
-  static void UpdateNontreeEdgeCounts(const ElemSeq& elements, IntSeq&& new_values);
+  static void UpdateNontreeEdgeCounts(const ElemSeq& elements, const IntSeq& new_values);
 
  private:
   friend Base::Base::Base;  // make parallel_skip_list::ElementBase a friend
@@ -185,8 +185,8 @@ parlay::sequence<std::pair<int, int>> HdtElement::ClearLevelIEdges() {
 }
 
 template <typename ElemSeq, typename IntSeq>
-void HdtElement::UpdateNontreeEdgeCounts(const ElemSeq& elements, IntSeq&& new_values) {
-  BatchUpdate<_internal::NontreeEdgeCountGetter>(elements, std::move(new_values));
+void HdtElement::UpdateNontreeEdgeCounts(const ElemSeq& elements, const IntSeq& new_values) {
+  BatchUpdate<_internal::NontreeEdgeCountGetter>(elements, new_values);
 }
 
 }  // namespace parallel_euler_tour_tree

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -115,7 +115,7 @@ class NontreeEdgeFinder {
   //     edges using FindNontreeIncidentVertices(100, 50).
   //
   template <typename Func>
-  void ForEachIncidentVertex(Func f, size_t num_non_tree_edges, size_t search_offset) const;
+  void ForEachIncidentVertex(Func f, uint64_t num_desired_edges, uint64_t search_offset) const;
 
   // TODO(tomtseng): comment
   uint64_t NumEdges() const;
@@ -254,11 +254,21 @@ uint64_t NontreeEdgeFinder::NumEdges() const {
 template <typename F>
 void NontreeEdgeFinder::ForEachIncidentVertex(
     F f,
-    size_t num_non_tree_edges,
-    size_t search_offset) const {
+    uint64_t num_desired_edges,
+    uint64_t search_offset) const {
+  num_desired_edges = std::min<uint64_t>(num_incident_edges_ - search_offset, num_desired_edges);
+
+  const HdtElement* curr{top_element_};
   const int level{top_element_->height_ - 1};
-  exit(-1);
-  // TODO(tomtseng) impl
+  // TODO(tomtseng) parallelize
+  do {
+    const uint64_t num_edges_of_curr{std::get<2>(curr->values_[level])};
+    if (search_offset >= num_edges_of_curr) {
+      search_offset -= num_edges_of_curr;
+    } else {
+      // TODO(tomtseng) impl
+    }
+  } while (curr != top_element_);
 }
 
 }  // namespace parallel_euler_tour_tree

--- a/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
@@ -68,10 +68,10 @@ class NontreeEdgeFinder {
   // these edges are incident on to allow the caller to iterate over the edges.
   //
   // f should be a function capable of running in concurrently with other copies
-  // of itself and should have the interface `void f(uint32_t vertex_id,
-  // uint32_t begin, uint32_t end)` where the arguments signify that f should
-  // operate upon the `begin`-th (inclusive) to `end`-th (exclusive) level-i
-  // non-tree edges of vertex `vertex_id`.
+  // of itself and should have the interface `void f(int vertex_id, uint32_t
+  // begin, uint32_t end)` where the arguments signify that f should operate
+  // upon the `begin`-th (inclusive) to `end`-th (exclusive) level-i non-tree
+  // edges of vertex `vertex_id`.
   template <typename Func>
   void ForEachIncidentVertex(Func f, uint64_t edges_begin, uint64_t edges_end) const;
 

--- a/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
@@ -242,6 +242,9 @@ void NontreeEdgeFinder::ForEachIncidentVertexImpl(
 
 template <typename F>
 void NontreeEdgeFinder::ForEachIncidentVertex(F f, uint64_t l, uint64_t r) const {
+  if (l >= r) {
+    return;
+  }
   const int level{top_element_->height_ - 1};
   ForEachIncidentVertexImpl(f, r - l, l, level, top_element_);
 }

--- a/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
@@ -35,7 +35,7 @@ class HdtEulerTourTree : public EulerTourTreeBase<HdtElement> {
   template <typename IntSeq>
   void UpdateNontreeEdgeCounts(
       const parlay::sequence<int>& vertices,
-      IntSeq&& new_values);
+      const IntSeq& new_values);
 
   // Creates a NontreeEdgeFinder for v's connected component. The
   // NontreeEdgeFinder can be used to find level-i non-tree edges incident to
@@ -141,11 +141,11 @@ parlay::sequence<std::pair<int, int>> HdtEulerTourTree::ClearLevelIEdges(int v) 
 template <typename IntSeq>
 void HdtEulerTourTree::UpdateNontreeEdgeCounts(
     const parlay::sequence<int>& vertices,
-    IntSeq&& new_values) {
+    const IntSeq& new_values) {
   const auto elements{parlay::delayed_seq<Elem*>(
       vertices.size(),
       [&](size_t i) { return &vertices_[vertices[i]]; })};
-  Elem::UpdateNontreeEdgeCounts(elements, std::move(new_values));
+  Elem::UpdateNontreeEdgeCounts(elements, new_values);
 }
 
 NontreeEdgeFinder HdtEulerTourTree::CreateNontreeEdgeFinder(int v) const {

--- a/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
@@ -1,0 +1,246 @@
+#pragma once
+
+#include "euler_tour_tree.h"
+#include "hdt_element.h"
+
+namespace parallel_euler_tour_tree {
+
+class HdtEulerTourTree : public EulerTourTreeBase<HdtElement> {
+ public:
+  HdtEulerTourTree(int num_vertices);
+
+  // Adds an edge to the forest.
+  //
+  // `is_level_i_edge` refers to whether this element represents a level-i edge,
+  // where "level-i" refers to the level (in the HDT algorithm) of this ETT.
+  void Link(int u, int v, bool is_level_i_edge);
+  // Adds edges to the forest, where `is_level_i_edge[i]` corresponds to whether
+  // links[i] is a level-i edge.
+  template <typename BoolSeq>
+  void BatchLink(
+      const parlay::sequence<std::pair<int, int>>& links,
+      const BoolSeq& is_level_i_edge);
+
+  // Get the number of vertices in v's connected component.
+  size_t ComponentSize(int v) const;
+
+  // In v's connected component, return all level-i tree edges and mark them as
+  // no longer being level-i tree edges (because they're going to be pushed down
+  // to the next level).
+  parlay::sequence<std::pair<int, int>> ClearLevelIEdges(int v);
+
+  // Updates vertices[i]'s count of "number of level-i non-tree edges incident to this
+  // vertex" to be new_values[i].
+  template <typename IntSeq>
+  void UpdateNontreeEdgeCounts(
+      const parlay::sequence<int>& vertices,
+      IntSeq&& new_values);
+
+  // Creates a NontreeEdgeFinder for v's connected component. The
+  // NontreeEdgeFinder can be used to find level-i non-tree edges incident to
+  // the component
+  NontreeEdgeFinder CreateNontreeEdgeFinder(int v) const;
+
+ private:
+  using Base = EulerTourTreeBase<HdtElement>;
+  using Elem = HdtElement;
+};
+
+// A NontreeEdgeFinder finds level-i non-tree edges incident to a particular
+// connected component.
+//
+// The NontreeEdgeFinder is no longer valid if the component is modified by a
+// link, a cut, or a UpdateNontreeEdgeCounts().
+class NontreeEdgeFinder {
+ public:
+  // The returns the number of level-i non-tree edges incident to the connected
+  // component.
+  uint64_t NumEdges() const;
+
+  // This function finds vertices in the component that have incident level-i
+  // non-tree edges and applies `f` to the vertices. The edges found are the
+  // first `num_edges` edges after skipping the first `search_offset` edges.
+  //
+  // Params:
+  // - f: A parallel function to apply to vertices that have incident edges. The
+  //   interface of f should be `void f(uint32_t vertex_id, uint32_t begin,
+  //   uint32_t end)` where the arguments signify that f should operate upon the
+  //   `begin`-th (inclusive) to `end`-th (exclusive) level-i non-tree edges of
+  //   vertex `vertex_id`.
+  // - num_edges: Specifies how many level-i non-tree edges to search for.
+  // - search_offset: Specifies prefix of non-tree edges to skip in the search.
+  //   For instance, suppose you've already found 50 edges using
+  //   FindNontreeIncidentVertices(f, 50, 0). Then you can find the next 20 edges
+  //   using FindNontreeIncidentVertices(f, 20, 50).
+  template <typename Func>
+  void ForEachIncidentVertex(Func f, uint64_t num_desired_edges, uint64_t search_offset) const;
+
+ private:
+  friend HdtEulerTourTree;
+
+  NontreeEdgeFinder(const HdtElement* top_element);
+
+  template <typename F>
+  void ForEachIncidentVertexImpl(
+      F f,
+      uint64_t num_desired_edges,
+      uint64_t search_offset,
+      int level,
+      const HdtElement* element) const;
+
+  // A fixed representative element of the list representing the connected component.
+  const HdtElement* top_element_;
+  // The number of level-i non-tree edges incident to the component.
+  uint64_t num_incident_edges_{0};
+};
+
+///////////////////////////////////////////////////////////////////////////////
+//                  HdtEulerTourTree Implementation below.                   //
+///////////////////////////////////////////////////////////////////////////////
+
+HdtEulerTourTree::HdtEulerTourTree(int num_vertices) : Base{num_vertices} {}
+
+void HdtEulerTourTree::Link(int u, int v, bool is_level_i_edge) {
+  Elem* uv = ElementAllocator::alloc();
+  Elem* vu = ElementAllocator::alloc();
+  new (uv) Elem{randomness_.ith_rand(0), make_pair(u, v), is_level_i_edge};
+  new (vu) Elem{randomness_.ith_rand(1), make_pair(v, u), is_level_i_edge};
+  randomness_ = randomness_.next();
+  Base::Link(u, v, uv, vu);
+}
+
+template <typename BoolSeq>
+void HdtEulerTourTree::BatchLink(
+    const parlay::sequence<std::pair<int, int>>& links,
+    const BoolSeq& is_level_i_edge) {
+  const auto construct{[&](parlay::random* randomness, size_t i, Elem* uv, Elem* vu) {
+    const int u{links[i].first};
+    const int v{links[i].second};
+    const bool is_level_i{is_level_i_edge[i]};
+    new (uv) Elem{randomness->ith_rand(2 * i), make_pair(u, v), is_level_i};
+    new (vu) Elem{randomness->ith_rand(2 * i + 1), make_pair(v, u), is_level_i};
+  }};
+  Base::BatchLink(links, construct);
+}
+
+size_t HdtEulerTourTree::ComponentSize(int v) const {
+  return vertices_[v].GetComponentSize();
+}
+
+parlay::sequence<std::pair<int, int>> HdtEulerTourTree::ClearLevelIEdges(int v) {
+  return vertices_[v].ClearLevelIEdges();
+}
+
+template <typename IntSeq>
+void HdtEulerTourTree::UpdateNontreeEdgeCounts(
+    const parlay::sequence<int>& vertices,
+    IntSeq&& new_values) {
+  const auto elements{parlay::delayed_seq<Elem*>(
+      vertices.size(),
+      [&](size_t i) { return &vertices_[vertices[i]]; })};
+  Elem::UpdateNontreeEdgeCounts(elements, std::move(new_values));
+}
+
+NontreeEdgeFinder HdtEulerTourTree::CreateNontreeEdgeFinder(int v) const {
+  return NontreeEdgeFinder{vertices_[v].FindRepresentative()};
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//                  NontreeEdgeFinder Implementation below.                  //
+///////////////////////////////////////////////////////////////////////////////
+
+// Implementation notes:
+// - We implement this as separate class from HdtElement just to avoid recalculating
+//   top_element_ every time we call ForEachIncidentVertex. This optimization is
+//   probably completely insignificant.
+
+NontreeEdgeFinder::NontreeEdgeFinder(const HdtElement* top_element)
+  : top_element_{top_element} {
+  const HdtElement* curr{top_element};
+  const int level{top_element_->height_ - 1};
+  do {
+    num_incident_edges_ += std::get<2>(curr->values_[level]);
+    curr = curr->neighbors_[level].next;
+  } while (curr != top_element);
+}
+
+uint64_t NontreeEdgeFinder::NumEdges() const {
+  return num_incident_edges_;
+}
+
+// Helper function for ForEachIncidentVertex. Starting at `element`, the
+// function traverses along `level` until reaching its right parent or returning
+// back to `top_element_`. While traversing, the function searches for the first
+// `num_desired_edges` level-i non-tree edges after skipping the first
+// `search_offset` edges.
+template <typename F>
+void NontreeEdgeFinder::ForEachIncidentVertexImpl(
+    F f,
+    uint64_t num_desired_edges,
+    uint64_t search_offset,
+    int level,
+    const HdtElement* element) const {
+  if (level <= 6) {
+    // run sequentially if we're near the bottom of the list and not doing as
+    // much work per thread
+    do {
+      const uint64_t num_edges{std::get<2>(element->values_[level])};
+      if (search_offset >= num_edges) {
+        search_offset -= num_edges;
+      } else {
+        if (level == 0) {
+          f(element->id_.first, search_offset, std::min<uint64_t>(search_offset + num_desired_edges, num_edges));
+        } else {
+          ForEachIncidentVertexImpl(f, num_desired_edges, search_offset, level - 1, element);
+        }
+        num_desired_edges -= std::min<uint64_t>(num_edges - search_offset, num_desired_edges);
+        search_offset = 0;
+      }
+      element = element->neighbors_[level].next;
+    } while (element->height_ <= level + 1 && num_desired_edges > 0 && element != top_element_);
+    return;
+  }
+
+  // run in parallel
+  struct LoopState {
+    const HdtElement* element;
+    uint64_t num_desired_edges;
+    uint64_t search_offset;
+  } loop_state = { element, num_desired_edges, search_offset };
+  const auto loop_condition{[&](const LoopState& state) {
+    return state.element->height_ <= level + 1 &&
+      num_desired_edges > 0 &&
+      element != top_element_;
+  }};
+  const auto loop_action{[&](const LoopState& state) {
+    const uint64_t num_edges{std::get<2>(state.element->values_[level])};
+    if (state.search_offset >= num_edges) {
+      return;
+    }
+    ForEachIncidentVertexImpl(f, state.num_desired_edges, state.search_offset, level - 1, state.element);
+  }};
+  const auto loop_update{[&](LoopState state) -> LoopState {
+    uint64_t num_edges{std::get<2>(state.element->values_[level])};
+    if (state.search_offset >= num_edges) {
+      state.search_offset -= num_edges;
+    } else {
+      state.num_desired_edges -= std::min<uint64_t>(num_edges - state.search_offset, state.num_desired_edges);
+      state.search_offset = 0;
+    }
+    state.element = state.element->neighbors_[level].next;
+    return state;
+  }};
+  constexpr bool is_do_while{true};
+  elektra::ParallelWhile(loop_condition, loop_action, loop_update, std::move(loop_state), is_do_while);
+}
+
+template <typename F>
+void NontreeEdgeFinder::ForEachIncidentVertex(
+    F f,
+    uint64_t num_desired_edges,
+    uint64_t search_offset) const {
+  const int level{top_element_->height_ - 1};
+  ForEachIncidentVertexImpl(f, num_desired_edges, search_offset, level, top_element_);
+}
+
+}  // namespace parallel_euler_tour_tree

--- a/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
@@ -17,9 +17,10 @@ class HdtEulerTourTree : public EulerTourTreeBase<HdtElement> {
   // Adds edges to the forest, where `is_level_i_edge[i]` corresponds to whether
   // links[i] is a level-i edge.
   template <typename BoolSeq>
-  void BatchLink(
-      const parlay::sequence<std::pair<int, int>>& links,
-      const BoolSeq& is_level_i_edge);
+  void BatchLink(const parlay::sequence<std::pair<int, int>>& links, const BoolSeq& is_level_i_edge);
+  // Adds edges to the forest, where `is_level_i_edge` corresponds to whether
+  // links[i] is a level-i edge.
+  void BatchLink(const parlay::sequence<std::pair<int, int>>& links, bool is_level_i_edge);
 
   // Get the number of vertices in v's connected component.
   size_t ComponentSize(int v) const;
@@ -121,6 +122,12 @@ void HdtEulerTourTree::BatchLink(
     new (vu) Elem{randomness->ith_rand(2 * i + 1), make_pair(v, u), is_level_i};
   }};
   Base::BatchLink(links, construct);
+}
+
+void HdtEulerTourTree::BatchLink(
+    const parlay::sequence<std::pair<int, int>>& links,
+    bool is_level_i_edge) {
+  BatchLink(links, parlay::delayed_seq<bool>(links.size(), [&](size_t) { return is_level_i_edge; }));
 }
 
 size_t HdtEulerTourTree::ComponentSize(int v) const {

--- a/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
@@ -28,7 +28,7 @@ class HdtEulerTourTree : public EulerTourTreeBase<HdtElement> {
   // In v's connected component, return all level-i tree edges and mark them as
   // no longer being level-i tree edges (because they're going to be pushed down
   // to the next level).
-  parlay::sequence<std::pair<int, int>> ClearLevelIEdges(int v);
+  parlay::sequence<std::pair<int, int>> GetAndClearLevelIEdges(int v);
 
   // Updates vertices[i]'s count of "number of level-i non-tree edges incident to this
   // vertex" to be new_values[i].
@@ -134,8 +134,8 @@ size_t HdtEulerTourTree::ComponentSize(int v) const {
   return vertices_[v].GetComponentSize();
 }
 
-parlay::sequence<std::pair<int, int>> HdtEulerTourTree::ClearLevelIEdges(int v) {
-  return vertices_[v].ClearLevelIEdges();
+parlay::sequence<std::pair<int, int>> HdtEulerTourTree::GetAndClearLevelIEdges(int v) {
+  return vertices_[v].GetAndClearLevelIEdges();
 }
 
 template <typename IntSeq>

--- a/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
@@ -114,12 +114,12 @@ template <typename BoolSeq>
 void HdtEulerTourTree::BatchLink(
     const parlay::sequence<std::pair<int, int>>& links,
     const BoolSeq& is_level_i_edge) {
-  const auto construct{[&](parlay::random* randomness, size_t i, Elem* uv, Elem* vu) {
+  const auto construct{[&](const parlay::random& randomness, size_t i, Elem* uv, Elem* vu) {
     const int u{links[i].first};
     const int v{links[i].second};
     const bool is_level_i{is_level_i_edge[i]};
-    new (uv) Elem{randomness->ith_rand(2 * i), make_pair(u, v), is_level_i};
-    new (vu) Elem{randomness->ith_rand(2 * i + 1), make_pair(v, u), is_level_i};
+    new (uv) Elem{randomness.ith_rand(2 * i), make_pair(u, v), is_level_i};
+    new (vu) Elem{randomness.ith_rand(2 * i + 1), make_pair(v, u), is_level_i};
   }};
   Base::BatchLink(links, construct);
 }

--- a/elektra/parallel_skip_list/augmented_skip_list.h
+++ b/elektra/parallel_skip_list/augmented_skip_list.h
@@ -91,7 +91,7 @@ class AugmentedElementBase : public ElementBase<Derived> {
   //     - changing x or y on the portion of `Func::T` captured by `Get` does
   //       not change `Func::f(x, y)` on the portion of `Func::T` not captured by `Get`
   template <typename Getter = DefaultGetter<Func>, typename ElemSeq, typename ValueSeq>
-  static void BatchUpdate(const ElemSeq& elements, ValueSeq&& new_values);
+  static void BatchUpdate(const ElemSeq& elements, const ValueSeq& new_values);
   // Updates augmented values of the elements' ancestors according to whatever
   // values already exist at elements[]->values_[0]. This is useful after calls
   // to JoinWithoutUpdate() and SplitWithoutUpdate().
@@ -295,10 +295,10 @@ void AugmentedElementBase<D, F>::UpdateTopDown(int level) {
 
 template <typename D, typename F>
 template <typename Getter, typename ElemSeq, typename ValueSeq>
-void AugmentedElementBase<D, F>::BatchUpdate(const ElemSeq& elements, ValueSeq&& new_values) {
+void AugmentedElementBase<D, F>::BatchUpdate(const ElemSeq& elements, const ValueSeq& new_values) {
   parlay::parallel_for(0, elements.size(), [&](size_t i) {
     if (elements[i] != nullptr) {
-      Getter::Get(elements[i]->values_[0]) = std::move(new_values[i]);
+      Getter::Get(elements[i]->values_[0]) = new_values[i];
     }
   });
   AugmentedElementBase<D, F>::BatchUpdate<Getter>(elements);

--- a/elektra/parallel_skip_list/augmented_skip_list.h
+++ b/elektra/parallel_skip_list/augmented_skip_list.h
@@ -316,13 +316,13 @@ void AugmentedElementBase<D, F>::BatchUpdate(const Seq& elements) {
   auto top_nodes{parlay::sequence<AugmentedElementBase<D, F>*>::uninitialized(len)};
 
   parlay::parallel_for(0, len, [&](const size_t i) {
-    if (elements[i] == nullptr) {
+    AugmentedElementBase<D, F>* curr{elements[i]};
+    if (curr == nullptr) {
       top_nodes[i] = nullptr;
       return;
     }
 
     int level{0};
-    AugmentedElementBase<D, F>* curr{elements[i]};
     while (true) {
       int curr_update_level{curr->update_level_};
       if (curr_update_level == _internal::NA && CAS(&curr->update_level_, _internal::NA, level)) {

--- a/test/elektra_test.cpp
+++ b/test/elektra_test.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "tests/test_augmented_skip_list.h"
+#include "tests/test_hdt_euler_tour_tree.h"
 #include "tests/test_parallel_batch_connected.h"
 #include "tests/test_parallel_euler_tour_tree.h"
 #include "tests/test_parallel_skip_list.h"

--- a/test/tests/test_hdt_euler_tour_tree.h
+++ b/test/tests/test_hdt_euler_tour_tree.h
@@ -2,6 +2,7 @@
 
 #include "../../elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <parlay/sequence.h>
 
@@ -9,6 +10,10 @@ namespace elektra::testing {
 namespace hdt_euler_tour_tree {
 
 using EulerTourTree = parallel_euler_tour_tree::HdtEulerTourTree;
+
+using ::testing::IsEmpty;
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
 
 TEST(HdtEulerTourTree, ComponentSize) {
   const int n = 6;
@@ -30,6 +35,29 @@ TEST(HdtEulerTourTree, ComponentSize) {
   ett.Cut(0, 3);
   EXPECT_EQ(ett.ComponentSize(2), 3);
   EXPECT_EQ(ett.ComponentSize(3), 2);
+}
+
+TEST(HdtEulerTourTree, GetAndClearLevelIEdges) {
+  const int n = 7;
+  EulerTourTree ett = EulerTourTree{n};
+
+  // 0 - 1   4   6
+  // | \     |
+  // 2   3   5
+  parlay::sequence<std::pair<int, int>> links{{
+    {0, 1},
+    {0, 2},
+    {0, 3},
+    {4, 5},
+  }};
+  parlay::sequence<bool> is_level_i_edge{{true, false, true, true}};
+  ett.BatchLink(links, is_level_i_edge);
+
+  EXPECT_THAT(ett.GetAndClearLevelIEdges(3), UnorderedElementsAre(Pair(0, 1), Pair(0, 3)));
+  EXPECT_THAT(ett.GetAndClearLevelIEdges(3), IsEmpty());
+  EXPECT_THAT(ett.GetAndClearLevelIEdges(4), UnorderedElementsAre(Pair(4, 5)));
+  EXPECT_THAT(ett.GetAndClearLevelIEdges(4), IsEmpty());
+  EXPECT_THAT(ett.GetAndClearLevelIEdges(6), IsEmpty());
 }
 
 }  // namespace hdt_element

--- a/test/tests/test_hdt_euler_tour_tree.h
+++ b/test/tests/test_hdt_euler_tour_tree.h
@@ -11,7 +11,7 @@ namespace hdt_euler_tour_tree {
 using EulerTourTree = parallel_euler_tour_tree::HdtEulerTourTree;
 
 TEST(HdtEulerTourTree, ComponentSize) {
-  const int n = 5;
+  const int n = 6;
   EulerTourTree ett = EulerTourTree{n};
 
   // 0 - 1   4

--- a/test/tests/test_hdt_euler_tour_tree.h
+++ b/test/tests/test_hdt_euler_tour_tree.h
@@ -11,30 +11,44 @@ namespace hdt_euler_tour_tree {
 
 using EulerTourTree = parallel_euler_tour_tree::HdtEulerTourTree;
 
+using ::testing::_;
+using ::testing::InSequence;
 using ::testing::IsEmpty;
+using ::testing::MockFunction;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
+using MockForEachIncidentVertexCallback = MockFunction<void(uint32_t, uint32_t, uint32_t)>;
+
+TEST(HdtEulerTourTree, ComponentSize_Singleton) {
+  EulerTourTree ett = EulerTourTree{1};
+  EXPECT_EQ(ett.ComponentSize(0), 1);
+}
+
 TEST(HdtEulerTourTree, ComponentSize) {
-  const int n = 6;
+  const int n = 5;
   EulerTourTree ett = EulerTourTree{n};
 
-  // 0 - 1   4
+  // 0 - 1
   // | \
-  // 2   3 - 5
+  // 2   3 - 4
   parlay::sequence<std::pair<int, int>> links{{
     {0, 1},
     {0, 2},
     {0, 3},
-    {5, 3},
+    {4, 3},
   }};
   ett.BatchLink(links, false);
   EXPECT_EQ(ett.ComponentSize(3), 5);
-  EXPECT_EQ(ett.ComponentSize(4), 1);
 
   ett.Cut(0, 3);
   EXPECT_EQ(ett.ComponentSize(2), 3);
   EXPECT_EQ(ett.ComponentSize(3), 2);
+}
+
+TEST(HdtEulerTourTree, GetAndClearLevelIEdges_Singleton) {
+  EulerTourTree ett = EulerTourTree{1};
+  EXPECT_THAT(ett.GetAndClearLevelIEdges(0), IsEmpty());
 }
 
 TEST(HdtEulerTourTree, GetAndClearLevelIEdges) {
@@ -58,6 +72,31 @@ TEST(HdtEulerTourTree, GetAndClearLevelIEdges) {
   EXPECT_THAT(ett.GetAndClearLevelIEdges(4), UnorderedElementsAre(Pair(4, 5)));
   EXPECT_THAT(ett.GetAndClearLevelIEdges(4), IsEmpty());
   EXPECT_THAT(ett.GetAndClearLevelIEdges(6), IsEmpty());
+}
+
+TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithoutEdges) {
+  EulerTourTree ett = EulerTourTree{1};
+  const auto finder = ett.CreateNontreeEdgeFinder(0);
+
+  MockForEachIncidentVertexCallback mock_callback;
+  EXPECT_CALL(mock_callback, Call(_, _, _)).Times(0);
+
+  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 0, 100);
+  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 20, 40);
+}
+
+TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithEdges) {
+  EulerTourTree ett = EulerTourTree{1};
+  ett.UpdateNontreeEdgeCounts({0}, parlay::sequence<int>(1, 50));
+  const auto finder = ett.CreateNontreeEdgeFinder(0);
+
+  InSequence s;
+  MockForEachIncidentVertexCallback mock_callback;
+  EXPECT_CALL(mock_callback, Call(0, 0, 50));
+  EXPECT_CALL(mock_callback, Call(0, 20, 40));
+
+  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 0, 100);
+  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 20, 40);
 }
 
 }  // namespace hdt_element

--- a/test/tests/test_hdt_euler_tour_tree.h
+++ b/test/tests/test_hdt_euler_tour_tree.h
@@ -18,9 +18,10 @@ using ::testing::MockFunction;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
-using MockForEachIncidentVertexCallback = MockFunction<void(uint32_t, uint32_t, uint32_t)>;
+using MockForEachIncidentVertexCallback = MockFunction<void(int, uint32_t, uint32_t)>;
 
 TEST(HdtEulerTourTree, ComponentSize_Singleton) {
+  // Check ComponentSize() works on a singleton vertex.
   EulerTourTree ett = EulerTourTree{1};
   EXPECT_EQ(ett.ComponentSize(0), 1);
 }
@@ -32,12 +33,7 @@ TEST(HdtEulerTourTree, ComponentSize) {
   // 0 - 1
   // | \
   // 2   3 - 4
-  parlay::sequence<std::pair<int, int>> links{{
-    {0, 1},
-    {0, 2},
-    {0, 3},
-    {4, 3},
-  }};
+  parlay::sequence<std::pair<int, int>> links{{{0, 1}, {0, 2}, {0, 3}, {4, 3}}};
   ett.BatchLink(links, false);
   EXPECT_EQ(ett.ComponentSize(3), 5);
 
@@ -47,6 +43,7 @@ TEST(HdtEulerTourTree, ComponentSize) {
 }
 
 TEST(HdtEulerTourTree, GetAndClearLevelIEdges_Singleton) {
+  // Check GetAndClearLevelIEdges() works on a singleton vertex.
   EulerTourTree ett = EulerTourTree{1};
   EXPECT_THAT(ett.GetAndClearLevelIEdges(0), IsEmpty());
 }
@@ -58,12 +55,7 @@ TEST(HdtEulerTourTree, GetAndClearLevelIEdges) {
   // 0 - 1   4   6
   // | \     |
   // 2   3   5
-  parlay::sequence<std::pair<int, int>> links{{
-    {0, 1},
-    {0, 2},
-    {0, 3},
-    {4, 5},
-  }};
+  parlay::sequence<std::pair<int, int>> links{{{0, 1}, {0, 2}, {0, 3}, {4, 5}}};
   parlay::sequence<bool> is_level_i_edge{{true, false, true, true}};
   ett.BatchLink(links, is_level_i_edge);
 
@@ -75,17 +67,22 @@ TEST(HdtEulerTourTree, GetAndClearLevelIEdges) {
 }
 
 TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithoutEdges) {
+  // Check FindNonTreeEdges() works on a singleton vertex without any incident
+  // non-tree edges.
   EulerTourTree ett = EulerTourTree{1};
   const auto finder = ett.CreateNontreeEdgeFinder(0);
 
   MockForEachIncidentVertexCallback mock_callback;
   EXPECT_CALL(mock_callback, Call(_, _, _)).Times(0);
 
+  EXPECT_EQ(finder.NumEdges(), 0);
   finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 0, 100);
   finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 20, 40);
 }
 
 TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithEdges) {
+  // Check FindNonTreeEdges() works on a singleton vertex with incident non-tree
+  // edges.
   EulerTourTree ett = EulerTourTree{1};
   ett.UpdateNontreeEdgeCounts({0}, parlay::sequence<int>(1, 50));
   const auto finder = ett.CreateNontreeEdgeFinder(0);
@@ -94,9 +91,101 @@ TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithEdges) {
   MockForEachIncidentVertexCallback mock_callback;
   EXPECT_CALL(mock_callback, Call(0, 0, 50));
   EXPECT_CALL(mock_callback, Call(0, 20, 40));
+  EXPECT_CALL(mock_callback, Call(0, 1, 2));
+
+  EXPECT_EQ(finder.NumEdges(), 50);
+  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 0, 100);
+  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 20, 40);
+  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 1, 1);
+  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 1, 2);
+}
+
+TEST(HdtEulerTourTree, FindNonTreeEdges_NoEdges) {
+  EulerTourTree ett = EulerTourTree{5};
+
+  // 0 - 1
+  // | \
+  // 2   3 - 4
+  parlay::sequence<std::pair<int, int>> links{{{0, 1}, {0, 2}, {0, 3}, {4, 3}}};
+  ett.BatchLink(links, false);
+
+  const auto finder = ett.CreateNontreeEdgeFinder(0);
+  MockForEachIncidentVertexCallback mock_callback;
+  EXPECT_CALL(mock_callback, Call(_, _, _)).Times(0);
 
   finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 0, 100);
   finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 20, 40);
+}
+
+TEST(HdtEulerTourTree, FindNonTreeEdges) {
+  // Check FindNonTreeEdges() works.
+  int n = 5;
+  EulerTourTree ett = EulerTourTree{n};
+  // 0 - 1
+  // | \
+  // 2   3   4
+  parlay::sequence<std::pair<int, int>> links{{{0, 1}, {0, 2}, {0, 3}}};
+  ett.BatchLink(links, false);
+
+  parlay::sequence<int> edge_counts = {0, 3, 1, 4, 5};
+  ett.UpdateNontreeEdgeCounts({0, 1, 2, 3, 4}, edge_counts);
+
+  // We don't know how the NontreeEdgeFinder will order the non-tree edges, so
+  // we'll explicitly track how many times each of the edges has been visited.
+  std::vector<std::vector<int>> edge_visit_counts(5, std::vector<int>{});
+
+  const auto visit = [&](int vertex_id, uint32_t start, uint32_t end) {
+    for (size_t i = start; i < end; i++) {
+      edge_visit_counts[vertex_id][i]++;
+    }
+  };
+  const auto reset_counts = [&]() {
+    for (int i = 0; i < n; i++) {
+      edge_visit_counts[i] = std::vector<int>(edge_counts[i], 0);
+    }
+  };
+  const auto sum_counts = [&]() {
+    int sum = 0;
+    for (int i = 0; i < n; i++) {
+      for (int j = 0; j < edge_counts[i]; j++) {
+        sum += edge_visit_counts[i][j];
+      }
+    }
+    return sum;
+  };
+  const auto unique_visits = [&]() {
+    int count = 0;
+    for (int i = 0; i < n; i++) {
+      for (int j = 0; j < edge_counts[i]; j++) {
+        if (edge_visit_counts[i][j] > 0) {
+          count++;
+        }
+      }
+    }
+    return count;
+  };
+
+  const auto finder = ett.CreateNontreeEdgeFinder(0);
+  EXPECT_EQ(finder.NumEdges(), 8);
+
+  // Check that querying disjoint intervals gives unique edges and gives the
+  // correct number of edges.
+  reset_counts();
+  finder.ForEachIncidentVertex(visit, 0, 2);
+  EXPECT_EQ(sum_counts(), 2);
+  finder.ForEachIncidentVertex(visit, 2, 6);
+  EXPECT_EQ(sum_counts(), 6);
+  finder.ForEachIncidentVertex(visit, 6, 7);
+  EXPECT_EQ(sum_counts(), 7);
+  EXPECT_EQ(unique_visits(), 7);
+
+  // Check that querying the same interval gives a deterministic answer
+  reset_counts();
+  finder.ForEachIncidentVertex(visit, 1, 4);
+  EXPECT_EQ(sum_counts(), 3);
+  finder.ForEachIncidentVertex(visit, 1, 4);
+  EXPECT_EQ(sum_counts(), 6);
+  EXPECT_EQ(unique_visits(), 3);
 }
 
 }  // namespace hdt_element

--- a/test/tests/test_hdt_euler_tour_tree.h
+++ b/test/tests/test_hdt_euler_tour_tree.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "../../elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h"
+
+#include "gtest/gtest.h"
+#include <parlay/sequence.h>
+
+namespace elektra::testing {
+namespace hdt_euler_tour_tree {
+
+using EulerTourTree = parallel_euler_tour_tree::HdtEulerTourTree;
+
+TEST(HdtEulerTourTree, ComponentSize) {
+  const int n = 5;
+  EulerTourTree ett = EulerTourTree{n};
+
+  // 0 - 1   4
+  // | \
+  // 2   3 - 5
+  parlay::sequence<std::pair<int, int>> links{{
+    {0, 1},
+    {0, 2},
+    {0, 3},
+    {5, 3},
+  }};
+  ett.BatchLink(links, false);
+  EXPECT_EQ(ett.ComponentSize(3), 5);
+  EXPECT_EQ(ett.ComponentSize(4), 1);
+
+  ett.Cut(0, 3);
+  EXPECT_EQ(ett.ComponentSize(2), 3);
+  EXPECT_EQ(ett.ComponentSize(3), 2);
+}
+
+}  // namespace hdt_element
+}  // namespace elektra::testing


### PR DESCRIPTION
This PR creates an `HdtEulerTourTree` class that supports several functions useful for HDT-like connectivity algorithms:
- Get and push down level-i tree edges
- Map over level-i non-tree edges
- Get component size

See `hdt_euler_tour_tree.h` for details.

## Testing

added small unit tests