### PR TITLE
skip_list: Reduce size by 8 bytes by moving fields; change `int height_` -> `int8_t height_`

### DIFF
--- a/elektra/parallel_skip_list/skip_list.h
+++ b/elektra/parallel_skip_list/skip_list.h
@@ -85,7 +85,7 @@ class ElementBase {
   // neighbors_[i] holds neighbors at level i, where level 0 is the lowest level
   // and is the level at which the list contains all elements
   Neighbors* neighbors_;
-  int height_;
+  int8_t height_;
 };
 
 // Basic phase-concurrent skip list. See interface of `ElementBase<T>`.


### PR DESCRIPTION
Moving `AugmentedListBase::update_level_` to be adjacent to `SkipListBase::height_` saves 8 bytes of space due to field alignment.

This PR also changes both fields to be `int8_t` instead of `int`; we don't allow the height of a skip list to exceed 32, so `int8_t` (holds values up to 127) is plenty.