### PR TITLE
ETT: Save 8 bytes per skip list element by allocated edge elements contiguously

### DIFF
--- a/elektra/parallel_euler_tour_tree/edge_map.h
+++ b/elektra/parallel_euler_tour_tree/edge_map.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <parlay/alloc.h>
 #include <parlay/parallel.h>
 #include <parlay/primitives.h>
 
 #include "concurrentMap.h"
 #include "element.h"
 #include "hash_pair.h"
+#include "utilities.h"
 
 namespace parallel_euler_tour_tree {
 
@@ -16,7 +16,7 @@ namespace _internal {
 // sequence element in the Euler tour representing the edge.
 //
 // Only one of (u, v) and (v, u) should be added to the map; we can find the
-// other edge using the `twin_` pointer in `Elem`.
+// other edge using OppositeEdge().
 template <typename Elem>
 class EdgeMap {
  public:
@@ -41,8 +41,6 @@ class EdgeMap {
   size_t AllocatedMemorySize() const;
 
  private:
-  using ElementAllocator = parlay::type_allocator<Elem>;
-
   concurrent_map::concurrentHT<std::pair<int, int>, Elem*, HashIntPairStruct>
       map_;
 };
@@ -63,7 +61,7 @@ template <typename Elem>
 bool EdgeMap<Elem>::Insert(int u, int v, Elem* edge) {
   if (u > v) {
     std::swap(u, v);
-    edge = edge->twin_;
+    edge = OppositeEdge(edge);
   }
   return map_.insert(make_pair(u, v), edge);
 }
@@ -80,24 +78,20 @@ template <typename Elem>
 Elem* EdgeMap<Elem>::Find(int u, int v) {
   if (u > v) {
     Elem* vu{*map_.find(make_pair(v, u))};
-    return vu == nullptr ? nullptr : vu->twin_;
+    return vu == nullptr ? nullptr : OppositeEdge(vu);
   } else {
     return *map_.find(make_pair(u, v));
   }
 }
 
-// Assumes that all elements were allocator using ElementAllocator.
 template <typename Elem>
 void EdgeMap<Elem>::FreeElements() {
   parlay::parallel_for(0, map_.capacity, [&](size_t i) {
     auto kv{map_.table[i]};
     auto key{get<0>(kv)};
     if (key != map_.empty_key && key != map_.tombstone) {
-      Elem* element{get<1>(kv)};
-      element->twin_->~Elem();
-      ElementAllocator::free(element->twin_);
-      element->~Elem();
-      ElementAllocator::free(element);
+      Elem* edge{get<1>(kv)};
+      DestroyEdges(edge);
     }
   });
 }
@@ -108,8 +102,8 @@ size_t EdgeMap<Elem>::AllocatedMemorySize() const {
     parlay::reduce(
       parlay::map(map_.entries(), [&](std::tuple<std::pair<int, int>, Elem*> kv) {
         const Elem* elem{std::get<1>(kv)};
-        // Count both elem and elem->twin_ since only one appears in map_.
-        return 2 * sizeof(*elem) + elem->AllocatedMemorySize() + elem->twin_->AllocatedMemorySize();
+        return 2 * sizeof(*elem)
+          + elem->AllocatedMemorySize() + OppositeEdge(elem)->AllocatedMemorySize();
       })
     );
 }

--- a/elektra/parallel_euler_tour_tree/element.h
+++ b/elektra/parallel_euler_tour_tree/element.h
@@ -35,8 +35,6 @@ class ElementBase : public parallel_skip_list::AugmentedElementBase<Derived, Fun
   // If this element represents a vertex v, then id == (v, v). Otherwise if
   // this element represents a directed edge (u, v), then id == (u,v).
   std::pair<int, int> id_;
-  // If this element represents edge (u, v), `twin` should point towards (v, u).
-  Derived* twin_{nullptr};
   // When batch splitting, we mark this as `true` for an edge that we will
   // splice out in the current round of recursion.
   bool split_mark_{false};

--- a/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/hdt_euler_tour_tree.h
@@ -2,6 +2,7 @@
 
 #include "euler_tour_tree.h"
 #include "hdt_element.h"
+#include "utilities.h"
 
 namespace parallel_euler_tour_tree {
 
@@ -103,8 +104,7 @@ class NontreeEdgeFinder {
 HdtEulerTourTree::HdtEulerTourTree(int num_vertices) : Base{num_vertices} {}
 
 void HdtEulerTourTree::Link(int u, int v, bool is_level_i_edge) {
-  Elem* uv = ElementAllocator::alloc();
-  Elem* vu = ElementAllocator::alloc();
+  auto [uv, vu] = _internal::AllocEdges<Elem>(u, v);
   new (uv) Elem{randomness_.ith_rand(0), make_pair(u, v), is_level_i_edge};
   new (vu) Elem{randomness_.ith_rand(1), make_pair(v, u), is_level_i_edge};
   randomness_ = randomness_.next();

--- a/elektra/parallel_euler_tour_tree/utilities.h
+++ b/elektra/parallel_euler_tour_tree/utilities.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <stdexcept>
+#include <sstream>
+#include <utility>
+
+#include <parlay/alloc.h>
+
+namespace parallel_euler_tour_tree {
+
+namespace _internal {
+
+// For an undirected edge {u,v}, we allocate elements representing (u,v) and
+// (v,u) contiguously.
+template <typename Elem>
+using EdgesAllocator = parlay::type_allocator<Elem[2]>;
+
+// Given an element representing edge (u, v), returns (v, u) (assuming that that
+// (u, v) and (v, u) are allocated contiguously).
+template <typename Elem>
+Elem* OppositeEdge(const Elem* uv) {
+  const auto [u, v] = uv->id_;
+  if (u < v) {
+    return const_cast<Elem*>(uv + 1);
+  } else if (u > v) {
+    return const_cast<Elem*>(uv - 1);
+  } else {
+    std::ostringstream errorMessage;
+    errorMessage << "expected edge, got ("
+      << uv->id_.first << ' '
+      << uv->id_.second;
+    throw std::invalid_argument(errorMessage.str());
+  }
+}
+
+// For an edge {u,v}, returns elements representing (u,v) and (v,u).
+template <typename Elem>
+std::pair<Elem*, Elem*> AllocEdges(int u, int v) {
+  Elem* edges = *EdgesAllocator<Elem>::alloc();
+  if (u < v) {
+    return {edges, edges + 1};
+  } else {
+    return {edges + 1, edges};
+  }
+}
+
+// For an edge {u,v}, destructs and frees the elements representing (u,v) and (v,u).
+template <typename Elem>
+void DestroyEdges(Elem* uv, Elem* vu) {
+  uv->~Elem();
+  vu->~Elem();
+  if (uv < vu) {
+    EdgesAllocator<Elem>::free(reinterpret_cast<Elem(*)[2]>(uv));
+  } else {
+    EdgesAllocator<Elem>::free(reinterpret_cast<Elem(*)[2]>(vu));
+  }
+}
+// Given edge (u, v), destroys and frees both (u, v) and (v, u).
+template <typename Elem>
+void DestroyEdges(Elem* uv) {
+  DestroyEdges(uv, OppositeEdge(uv));
+}
+
+}  // namespace _internal
+}  // namespace parallel_euler_tour_tree


### PR DESCRIPTION
## Description

For `EulerTourTreeBase::BatchSplit()`, we need to be able to find skip list element (v, u) given element (u, v). We were doing this by storing a pointer `twin_` on every skip list element. 

This PR removes `twin_` to save 8 bytes per element. We do this by allocating (u, v) and (v, u) adjacent to one another so that they can access each other by jumping forward or backward by `sizeof(Element)` bytes. 

## Testing

- ran unit tests with AddressSanitizer; tests still pass and AddressSanitizer did not report issues