### PR TITLE
dynamic_connectivity: Use HDT augmentation to search for replacement edges

### DIFF
--- a/elektra/batch_dynamic_connectivity/connectivity-helpers.h
+++ b/elektra/batch_dynamic_connectivity/connectivity-helpers.h
@@ -79,7 +79,7 @@ const bdcty::EInfo kEmptyInfo = {-1, bdcty::EType::K_NON_TREE};
 // make a hashtable with an empty value type
 // hash32 is sufficient
 struct hash_kv {
-  auto operator()(const V &k) -> uint64_t { return parlay::hash64(k); }
+  auto operator()(const V &k) const -> uint64_t { return parlay::hash64(k); }
 };
 
 using VertexConcurrentSet =

--- a/elektra/batch_dynamic_connectivity/connectivity-helpers.h
+++ b/elektra/batch_dynamic_connectivity/connectivity-helpers.h
@@ -17,7 +17,7 @@
 #include "hash_pair.h"
 #include "hash_table_utils.h"
 #include "macros.h"
-#include "parallel_euler_tour_tree/euler_tour_tree.h"
+#include "parallel_euler_tour_tree/hdt_euler_tour_tree.h"
 #include "resizable_table.h"
 #include "spanning_tree.h"
 #include "union_find.h"
@@ -44,11 +44,12 @@ using uintE = unsigned int;
 
 using E = pair<V, V>;
 using EHash = HashIntPairStruct;
-using BatchDynamicEtt = parallel_euler_tour_tree::EulerTourTree;
+using BatchDynamicEtt = parallel_euler_tour_tree::HdtEulerTourTree;
 
 using TreeSet = std::unordered_set<E, EHash>;
 
 using Level = int;
+constexpr Level kLevel_Max = 65;
 
 enum class EType {
   // Edge is in the spanning forest of the graph.

--- a/elektra/batch_dynamic_connectivity/connectivity.h
+++ b/elektra/batch_dynamic_connectivity/connectivity.h
@@ -97,9 +97,6 @@ private:
       -> parlay::sequence<V>;
   inline void InsertIntoEdgeTable(const pair<V, V> &e, EType e_type,
                                   Level level);
-  inline auto GetSearchEdges(Level level, sequence<V> &components,
-                             const unique_ptr<BatchDynamicEtt> &ett)
-      -> vector<vector<E>>;
 };
 
 void BatchDynamicConnectivity::CheckRep() {
@@ -400,31 +397,6 @@ inline void BatchDynamicConnectivity::InsertIntoEdgeTable(const pair<V, V> &e,
   // inserting the reverse edge add the reverse edge to the edges_ map
   EInfo ei_rev = {level, e_type};
   edges_.insert(make_tuple(pair<V, V>(e.second, e.first), ei_rev));
-}
-
-// TODO(tom): This needs to be supported as an augmentation.
-inline auto
-BatchDynamicConnectivity::GetSearchEdges(Level level, sequence<V> &components,
-                                         const unique_ptr<BatchDynamicEtt> &ett)
-    -> vector<vector<E>> {
-  vector<vector<E>> non_tree_edges;
-  non_tree_edges.reserve(components.size());
-  for (auto _ : components) {
-    non_tree_edges.emplace_back();
-  }
-  for (uintE i = 0; i < components.size(); i++) {
-    auto comp_id = components[i];
-    auto cc = ett->ComponentVertices(comp_id);
-    // for each vertex in the component
-    for (V u : cc) {
-      // for each edge in the component
-      for (auto &kw : non_tree_adjacency_lists_[level][u].entries()) {
-        auto w = std::get<0>(kw);
-        non_tree_edges[i].push_back(E(u, w));
-      }
-    }
-  }
-  return non_tree_edges;
 }
 
 auto BatchDynamicConnectivity::RemoveDuplicates(sequence<V> &seq)

--- a/elektra/batch_dynamic_connectivity/connectivity.h
+++ b/elektra/batch_dynamic_connectivity/connectivity.h
@@ -85,12 +85,19 @@ private:
 
   void CheckRep();
 
+  // Returns
+  //   - a sequence E[] of level-i non-tree edges that should be promoted to be tree edges
+  //   - a subset of E[] representing all elements of E[] that should simultaneously be
+  //     pushed to level i - 1
+  //
+  // It is the caller's job to do the promotion of E[] and to push the subset,
+  // though this function takes care of pushing down non-promoted edges.
   auto ReplacementSearch(Level level, parlay::sequence<V> components)
-      -> parlay::sequence<E>;
+      -> std::pair<sequence<E>, elektra::resizable_table<E, elektra::empty, HashIntPairStruct>>;
 
   void PushDownTreeEdgesFromComponents(Level l,
                                        parlay::sequence<V> &components);
-  void PushDownNonTreeEdges(Level l, parlay::sequence<E> &non_tree_edges);
+  void PushDownNonTreeEdges(Level l, const parlay::sequence<E> &non_tree_edges);
 
   static auto RemoveDuplicates(parlay::sequence<V> &seq) -> parlay::sequence<V>;
   static auto RemoveDuplicates(parlay::sequence<V> &&seq)

--- a/elektra/batch_dynamic_connectivity/dynamic_connectivity.h
+++ b/elektra/batch_dynamic_connectivity/dynamic_connectivity.h
@@ -222,7 +222,7 @@ void BatchDynamicConnectivity::BatchDeleteEdges(sequence<E> &se) {
   levels = parlay::filter(levels, [&](auto& elem) {
       return elem.second != kLevel_Max;
   });
-  parlay::integer_sort_inplace(levels, [&](auto & elem) { return elem.second; });
+  parlay::integer_sort_inplace(levels, [&](auto &elem) { return (uint8_t)elem.second; });
   const auto unique_level_flags = parlay::delayed_seq<bool>(
       levels.size(),
       [&](const size_t i) {

--- a/elektra/batch_dynamic_connectivity/dynamic_connectivity.h
+++ b/elektra/batch_dynamic_connectivity/dynamic_connectivity.h
@@ -113,11 +113,9 @@ void BatchDynamicConnectivity::PushDownTreeEdgesFromComponents(
 
   parlay::parallel_for(0, components.size(), [&](size_t i) {
     auto c = components[i];
-    // auto tree_edges = euler_tree->ComponentEdges(c);
     auto tree_edges = euler_tree->GetAndClearLevelIEdges(c);
 
     // move all these edges to the euler_tree of level l-1
-    // euler_tree->BatchCut(tree_edges);
     lower_level_euler_tree->BatchLink(
         tree_edges,
         parlay::delayed_seq<bool>(tree_edges.size(), [](size_t) { return true; })
@@ -204,7 +202,7 @@ void BatchDynamicConnectivity::BatchDeleteEdges(sequence<E> &se) {
     } else {
       levels[i] = make_pair(E(kV_Max, kV_Max), kLevel_Max);
       tree_edges.push_back(se[i]);
-      // TODO URGENT(sualeh): fix this.
+      //      URGENT(sualeh): fix this.
       parlay::write_min(&min_tree_edge_level, kLevel, std::less<>());
     }
 
@@ -480,7 +478,7 @@ BatchDynamicConnectivity::ReplacementSearch(Level level, sequence<V> components)
 
       edge_finders[i].ForEachIncidentVertex(search_offset, search_offset + search_size,
           [&](V u, V adj_begin, V adj_end) {
-            // TODO(tom/sualeh): entries() here is inefficient. What we "should"
+            // TODO(sualeh) TODO(tom): entries() here is inefficient. What we "should"
             // do is only look at the `adj_begin`-th to `adj_end`-th edges in
             // level_non_tree_adjacency_lists[u]. But we don't have a nice way
             // of fetching such a range of edges out of level_non_tree_adjacency_lists[u].

--- a/elektra/concurrentMap.h
+++ b/elektra/concurrentMap.h
@@ -175,6 +175,17 @@ class concurrentHT {
       return k != empty_key && k != tombstone;
     });
   }
+
+  // Return keys in the map.
+  parlay::sequence<K> keys() const {
+    const auto slice = parlay::delayed_seq<K>(
+        capacity,
+        [&](const size_t i) { return std::get<0>(table[i]); }
+    );
+    return parlay::filter(slice, [&](const K& k) {
+      return k != empty_key && k != tombstone;
+    });
+  }
 };
 
 };  // namespace concurrent_map

--- a/elektra/parallel_euler_tour_tree/edge_map.h
+++ b/elektra/parallel_euler_tour_tree/edge_map.h
@@ -32,6 +32,9 @@ class EdgeMap {
 
   bool IsEmpty() const;
 
+  // Returns all edges in the map.
+  parlay::sequence<std::pair<v_int, v_int>> Keys() const;
+
   // Deallocate all elements held in the map. This assumes that all elements
   // in the map were allocated through `allocator`.
   void FreeElements();
@@ -87,6 +90,11 @@ Elem* EdgeMap<Elem>::Find(v_int u, v_int v) {
   } else {
     return *map_.find(make_pair(u, v));
   }
+}
+
+template <typename Elem>
+parlay::sequence<std::pair<v_int, v_int>> EdgeMap<Elem>::Keys() const {
+  return map_.keys();
 }
 
 template <typename Elem>

--- a/elektra/parallel_euler_tour_tree/euler_tour_tree.h
+++ b/elektra/parallel_euler_tour_tree/euler_tour_tree.h
@@ -73,7 +73,7 @@ public:
   // Prints the tree to stdout.
   void Print();
   // Returns all the edges in the tree.
-  std::vector<std::pair<v_int, v_int>> Edges_() const;
+  parlay::sequence<std::pair<v_int, v_int>> Edges_() const;
   // Returns an estimate of the amount of system memory in bytes this data
   // structure occupies.
   auto MemorySize() const -> size_t;
@@ -186,14 +186,7 @@ v_int EulerTourTreeBase<E>::GetRepresentative(v_int u) const {
 
 // Prints the tree to stdout.
 template <typename E> void EulerTourTreeBase<E>::Print() {
-  // make a set of all edges
-  std::unordered_set<std::pair<v_int, v_int>, HashIntPairStruct> edges;
-
-  for (v_int i = 0; i < num_vertices_; i++) {
-    for (const auto &edge : vertices_[i].GetEdges()) {
-      edges.insert(edge);
-    }
-  }
+  const auto edges = Edges_();
 
   // print all the edges
   for (const auto &edge : edges) {
@@ -203,24 +196,8 @@ template <typename E> void EulerTourTreeBase<E>::Print() {
 }
 
 template <typename E>
-std::vector<std::pair<v_int, v_int>> EulerTourTreeBase<E>::Edges_() const {
-  // make a set of all edges
-  std::unordered_set<std::pair<v_int, v_int>, HashIntPairStruct> edges;
-
-  for (v_int i = 0; i < num_vertices_; i++) {
-    for (const auto &edge : vertices_[i].GetEdges()) {
-      edges.insert(edge);
-    }
-  }
-
-  // copy the edges into a vector
-  std::vector<std::pair<v_int, v_int>> edges_vec;
-  edges_vec.reserve(edges.size());
-  for (const auto &edge : edges) {
-    edges_vec.push_back(edge);
-  }
-
-  return edges_vec;
+parlay::sequence<std::pair<v_int, v_int>> EulerTourTreeBase<E>::Edges_() const {
+  return edges_.Keys();
 }
 
 template <typename E> size_t EulerTourTreeBase<E>::MemorySize() const {

--- a/elektra/parallel_euler_tour_tree/hdt_element.h
+++ b/elektra/parallel_euler_tour_tree/hdt_element.h
@@ -74,11 +74,11 @@ class HdtElement : public ElementBase<HdtElement, _internal::HdtAugmentation> {
   // to be pushed down to the next level).
   parlay::sequence<std::pair<v_int, v_int>> GetAndClearLevelIEdges();
 
-  // For each HdtElement elements[i] (which should represent a vertex), updates
+  // For each HdtElement elements[i] (which should represent a vertex), increments
   // its count of "number of level-i non-tree edges incident to this element" to
   // be new_values[i].
   template <typename ElemSeq, typename IntSeq>
-  static void UpdateNontreeEdgeCounts(const ElemSeq& elements, const IntSeq& new_values);
+  static void IncrementNontreeEdgeCounts(const ElemSeq& elements, const IntSeq& increment);
 
  private:
   friend Base::Base::Base;  // make parallel_skip_list::ElementBase a friend
@@ -186,8 +186,8 @@ parlay::sequence<std::pair<v_int, v_int>> HdtElement::GetAndClearLevelIEdges() {
 }
 
 template <typename ElemSeq, typename IntSeq>
-void HdtElement::UpdateNontreeEdgeCounts(const ElemSeq& elements, const IntSeq& new_values) {
-  BatchUpdate<_internal::NontreeEdgeCountGetter>(elements, new_values);
+void HdtElement::IncrementNontreeEdgeCounts(const ElemSeq& elements, const IntSeq& increments) {
+  BatchIncrement<_internal::NontreeEdgeCountGetter>(elements, increments);
 }
 
 }  // namespace parallel_euler_tour_tree

--- a/elektra/parallel_skip_list/augmented_skip_list.h
+++ b/elektra/parallel_skip_list/augmented_skip_list.h
@@ -102,6 +102,10 @@ class AugmentedElementBase : public ElementBase<Derived> {
   template <typename Getter = DefaultGetter<Func>, typename Seq>
   static void BatchUpdate(const Seq& elements);
 
+  // Same as BatchUpdate but increments values instead of setting new values
+  template <typename Getter = DefaultGetter<Func>, typename ElemSeq, typename IntSeq>
+  static void BatchIncrement(const ElemSeq& elements, const IntSeq& increments);
+
   // Get the result of applying the augmentation function over the subsequence
   // between `left` and `right` inclusive.
   //
@@ -353,6 +357,17 @@ void AugmentedElementBase<D, F>::BatchUpdate(const Seq& elements) {
       top_nodes[i]->template UpdateTopDown<Getter>(top_nodes[i]->height_ - 1);
     }
   });
+}
+
+template <typename D, typename F>
+template <typename Getter, typename ElemSeq, typename IntSeq>
+void AugmentedElementBase<D, F>::BatchIncrement(const ElemSeq& elements, const IntSeq& increments) {
+  parlay::parallel_for(0, elements.size(), [&](size_t i) {
+    if (elements[i] != nullptr) {
+      Getter::Get(elements[i]->values_[0]) += increments[i];
+    }
+  });
+  AugmentedElementBase<D, F>::BatchUpdate<Getter>(elements);
 }
 
 template <typename D, typename F>

--- a/elektra/parallel_skip_list/augmented_skip_list.h
+++ b/elektra/parallel_skip_list/augmented_skip_list.h
@@ -374,11 +374,10 @@ template <typename D, typename F>
 void AugmentedElementBase<D, F>::BatchJoin(const parlay::sequence<std::pair<D*, D*>>& joins)
 {
   const size_t len{joins.size()};
-  auto join_lefts{parlay::sequence<D*>::uninitialized(len)};
   parlay::parallel_for(0, len, [&](const size_t i) {
     Join(joins[i].first, joins[i].second);
-    join_lefts[i] = joins[i].first;
   });
+  const auto join_lefts = parlay::delayed_seq<D*>(len, [&](const size_t i) { return joins[i].first; });
   BatchUpdate(join_lefts);
 }
 

--- a/elektra/resizable_table.h
+++ b/elektra/resizable_table.h
@@ -232,7 +232,7 @@ public:
     return empty_value;
   }
 
-  bool contains(K k) {
+  bool contains(K k) const {
     size_t h = firstIndex(k);
     while (1) {
       if (std::get<0>(table[h]) == k) {
@@ -245,7 +245,7 @@ public:
     return 0;
   }
 
-  bool contains(K k, V v) {
+  bool contains(K k, V v) const {
     size_t h = firstIndex(k);
     while (1) {
       if (std::get<0>(table[h]) == k && std::get<1>(table[h]) == v) {
@@ -280,7 +280,7 @@ public:
     });
   }
 
-  sequence<T> entries() {
+  sequence<T> entries() const {
     auto pred = [&](T &t) {
       return (std::get<0>(t) != empty_key &&
               std::get<0>(t) != std::get<0>(tombstone));
@@ -289,7 +289,7 @@ public:
     return parlay::filter(table_seq, pred);
   }
 
-  sequence<K> keys() {
+  sequence<K> keys() const {
     auto pred = [&](K &k) {
       return k != empty_key && k != std::get<0>(tombstone);
     };
@@ -298,7 +298,6 @@ public:
         return std::get<0>(table_seq[i]);
     });
     return parlay::filter(keys_seq, pred);
-  }
   }
 
   void clear() {

--- a/elektra/resizable_table.h
+++ b/elektra/resizable_table.h
@@ -81,7 +81,7 @@ public:
   KeyHash key_hash;
   sequence<size_t> cts;
 
-  inline size_t firstIndex(K &k) { return hashToRange(key_hash(k), mask); }
+  inline size_t firstIndex(K &k) const { return hashToRange(key_hash(k), mask); }
 
   void init_counts() {
     size_t workers = parlay::num_workers();
@@ -281,7 +281,7 @@ public:
   }
 
   sequence<T> entries() const {
-    auto pred = [&](T &t) {
+    auto pred = [&](const T &t) {
       return (std::get<0>(t) != empty_key &&
               std::get<0>(t) != std::get<0>(tombstone));
     };
@@ -290,7 +290,7 @@ public:
   }
 
   sequence<K> keys() const {
-    auto pred = [&](K &k) {
+    auto pred = [&](const K &k) {
       return k != empty_key && k != std::get<0>(tombstone);
     };
     auto table_seq = parlay::make_slice(table);

--- a/elektra/resizable_table.h
+++ b/elektra/resizable_table.h
@@ -289,6 +289,18 @@ public:
     return parlay::filter(table_seq, pred);
   }
 
+  sequence<K> keys() {
+    auto pred = [&](K &k) {
+      return k != empty_key && k != std::get<0>(tombstone);
+    };
+    auto table_seq = parlay::make_slice(table);
+    auto keys_seq = parlay::delayed_seq<K>(table_seq.size(), [&](const size_t i) {
+        return std::get<0>(table_seq[i]);
+    });
+    return parlay::filter(keys_seq, pred);
+  }
+  }
+
   void clear() {
     parlay::parallel_for(0, m, [&](size_t i) { table[i] = empty; });
   }

--- a/test/tests/test_hdt_euler_tour_tree.h
+++ b/test/tests/test_hdt_euler_tour_tree.h
@@ -86,8 +86,8 @@ TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithoutEdges) {
   EXPECT_CALL(mock_callback, Call(_, _, _)).Times(0);
 
   EXPECT_EQ(finder.NumEdges(), 0);
-  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 0, 100);
-  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 20, 40);
+  finder.ForEachIncidentVertex(0, 100, mock_callback.AsStdFunction());
+  finder.ForEachIncidentVertex(20, 40, mock_callback.AsStdFunction());
 }
 
 TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithEdges) {
@@ -104,10 +104,10 @@ TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithEdges) {
   EXPECT_CALL(mock_callback, Call(0, 1, 2));
 
   EXPECT_EQ(finder.NumEdges(), 50);
-  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 0, 100);
-  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 20, 40);
-  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 1, 1);
-  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 1, 2);
+  finder.ForEachIncidentVertex(0, 100, mock_callback.AsStdFunction());
+  finder.ForEachIncidentVertex(20, 40, mock_callback.AsStdFunction());
+  finder.ForEachIncidentVertex(1, 1, mock_callback.AsStdFunction());
+  finder.ForEachIncidentVertex(1, 2, mock_callback.AsStdFunction());
 }
 
 TEST(HdtEulerTourTree, FindNonTreeEdges_NoEdges) {
@@ -123,8 +123,8 @@ TEST(HdtEulerTourTree, FindNonTreeEdges_NoEdges) {
   MockForEachIncidentVertexCallback mock_callback;
   EXPECT_CALL(mock_callback, Call(_, _, _)).Times(0);
 
-  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 0, 100);
-  finder.ForEachIncidentVertex(mock_callback.AsStdFunction(), 20, 40);
+  finder.ForEachIncidentVertex(0, 100, mock_callback.AsStdFunction());
+  finder.ForEachIncidentVertex(20, 40, mock_callback.AsStdFunction());
 }
 
 TEST(HdtEulerTourTree, FindNonTreeEdges) {
@@ -181,19 +181,19 @@ TEST(HdtEulerTourTree, FindNonTreeEdges) {
   // Check that querying disjoint intervals gives unique edges and gives the
   // correct number of edges.
   reset_counts();
-  finder.ForEachIncidentVertex(visit, 0, 2);
+  finder.ForEachIncidentVertex(0, 2, visit);
   EXPECT_EQ(sum_counts(), 2);
-  finder.ForEachIncidentVertex(visit, 2, 6);
+  finder.ForEachIncidentVertex(2, 6, visit);
   EXPECT_EQ(sum_counts(), 6);
-  finder.ForEachIncidentVertex(visit, 6, 7);
+  finder.ForEachIncidentVertex(6, 7, visit);
   EXPECT_EQ(sum_counts(), 7);
   EXPECT_EQ(unique_visits(), 7);
 
   // Check that querying the same interval gives a deterministic answer
   reset_counts();
-  finder.ForEachIncidentVertex(visit, 1, 4);
+  finder.ForEachIncidentVertex(1, 4, visit);
   EXPECT_EQ(sum_counts(), 3);
-  finder.ForEachIncidentVertex(visit, 1, 4);
+  finder.ForEachIncidentVertex(1, 4, visit);
   EXPECT_EQ(sum_counts(), 6);
   EXPECT_EQ(unique_visits(), 3);
 }

--- a/test/tests/test_hdt_euler_tour_tree.h
+++ b/test/tests/test_hdt_euler_tour_tree.h
@@ -94,7 +94,7 @@ TEST(HdtEulerTourTree, FindNonTreeEdges_SingletonWithEdges) {
   // Check FindNonTreeEdges() works on a singleton vertex with incident non-tree
   // edges.
   EulerTourTree ett = EulerTourTree{1};
-  ett.UpdateNontreeEdgeCounts({0}, parlay::sequence<uint32_t>(1, 50));
+  ett.IncrementNontreeEdgeCounts(parlay::sequence<uint32_t>(1, 0), parlay::sequence<uint32_t>(1, 50));
   const auto finder = ett.CreateNontreeEdgeFinder(0);
 
   InSequence s;
@@ -137,8 +137,9 @@ TEST(HdtEulerTourTree, FindNonTreeEdges) {
   parlay::sequence<std::pair<uint32_t, uint32_t>> links{{{0, 1}, {0, 2}, {0, 3}}};
   ett.BatchLink(links, false);
 
-  parlay::sequence<uint32_t> edge_counts = {0, 3, 1, 4, 5};
-  ett.UpdateNontreeEdgeCounts({0, 1, 2, 3, 4}, edge_counts);
+  const parlay::sequence<uint32_t> vertices = {0, 1, 2, 3, 4};
+  const parlay::sequence<uint32_t> edge_counts = {0, 3, 1, 4, 5};
+  ett.IncrementNontreeEdgeCounts(vertices, edge_counts);
 
   // We don't know how the NontreeEdgeFinder will order the non-tree edges, so
   // we'll explicitly track how many times each of the edges has been visited.


### PR DESCRIPTION
dynamic_connectivity currently searches for replacement edges by fetching every non-tree edge incident on a component up front. This PR changes the search to make use of the HDT augmentation.

This PR compiles but has not been tested at all since `main` currently fails an assertion